### PR TITLE
Enable architecture selection for OpenBSD, defaulting to amd64

### DIFF
--- a/lib/vm-guest
+++ b/lib/vm-guest
@@ -83,6 +83,7 @@ __guest_netbsd(){
 # open of the awkward guests that have version in kernel load path
 __guest_openbsd(){
 	local _gver=$(sysrc -inqf "${_conf}" guest_version)
+	local _arch=$(sysrc -inqf "${vm_dir}/${_name}/${_name}.conf" arch)
 
 	if [ -z "${_gver}" ]; then
 		__log "guest" "${_name}" "openbsd machines require \"guest_version\" value in configuration"
@@ -91,7 +92,7 @@ __guest_openbsd(){
 		if [ "$1" = "install" ]; then
 			__log_and_write "write" "${_name}" "device.map" "(hd0) ${_bootdisk}"
 			__log_and_write "appnd" "${_name}" "device.map" "(cd0) ${vm_dir}/.iso/${_iso}"
-			__log_and_write "write" "${_name}" "boot.cmd" "kopenbsd -h com0 /${_gver}/amd64/bsd.rd"
+			__log_and_write "write" "${_name}" "boot.cmd" "kopenbsd -h com0 /${_gver}/${_arch:-amd64}/bsd.rd"
 			__log_and_write "appnd" "${_name}" "boot.cmd" "boot"
 			__log "guest" "${_name}" "grub-bhyve -r cd0 -m ${vm_dir}/${_name}/device.map -M ${_memory} ${_name} < ${vm_dir}/${_name}/boot.cmd"
 			grub-bhyve -r cd0 -m "${vm_dir}/${_name}/device.map" -M "${_memory}" "${_name}" < "${vm_dir}/${_name}/boot.cmd"


### PR DESCRIPTION
Nice set of scripts.
I am using bhyve to prepare images for some embedded i386 devices. This simple change makes life easier.