### PR TITLE
image: take recursive snapshots

### DIFF
--- a/lib/vm-zfs
+++ b/lib/vm-zfs
@@ -117,7 +117,7 @@ __zfs_image_create(){
 	fi
 
 	# try to snapshot
-	zfs snapshot "${VM_ZFS_DATASET}/${_name}@${_uuid}" >/dev/null 2>&1
+	zfs snapshot -r "${VM_ZFS_DATASET}/${_name}@${_uuid}" >/dev/null 2>&1
 	[ $? -ne 0 ] && __err "failed to create snapshot of source dataset ${VM_ZFS_DATASET}/${_name}@${_uuid}"
 
 	# copy source


### PR DESCRIPTION
If a VM is using zvol, it allows to capture it in the snapshot as well,
otherwise vm image create fails with:

    WARNING: could not send zroot/vm/<vm name>/disk0@0baa7cab-e5ed-11e4-8889-38eaa7151bc4: does not exist