### PR TITLE
Fix use of - and . in VM names. Fix a typo while here.

### DIFF
--- a/lib/vm-common
+++ b/lib/vm-common
@@ -72,7 +72,7 @@ __restart_service(){
 #
 __usage(){
 cat << EOT
-vm: Bhyve virtual machine managament v${VERSION}
+vm: Bhyve virtual machine management v${VERSION}
 Usage: vm ...
     init
     switch list

--- a/lib/vm-core
+++ b/lib/vm-core
@@ -92,7 +92,7 @@ __vm_create(){
     _name=$1
 
     [ -z "${_name}" ] && __usage
-    echo "${_name}" | egrep -iqs '^[a-z0-9][a-z0-9\-\.]{0,14}[a-z0-9]$'
+    echo "${_name}" | egrep -iqs '^[a-z0-9][.a-z0-9-]{0,14}[a-z0-9]$'
     [ $? -ne 0 ] && __err "invalid virtual machine name '${_name}'"
 
     : ${_size:=20G}


### PR DESCRIPTION
Might be a better way to fix this, but it works fine as is. Prior to this, attempts to create a VM with a - in the name resulted in "invalid virtual machine name". I'm using VMs with - in the name with this change with no problem. 