### PR TITLE
Initialize vm_enable to avoid warning message at startup.

### DIFF
--- a/rc.d/vm
+++ b/rc.d/vm
@@ -8,6 +8,8 @@
 
 . /etc/rc.subr
 
+: ${vm_enable="NO"}
+
 name=vm
 desc="Start and stop vm-bhyve guests on boot/shutdown"
 rcvar=vm_enable


### PR DESCRIPTION
This prevents "WARNING: $vm_enable is not set properly - see rc.conf(5)." from showing up at boot.