### PR TITLE
Respect forcestart parameter

### DIFF
--- a/rc.d/vm
+++ b/rc.d/vm
@@ -22,8 +22,8 @@ stop_cmd="${command} stopall"
 
 vm_start()
 {
-    ${command} init
-    ${command} startall >/dev/null &
+    env rc_force="$rc_force" ${command} init
+    env rc_force="$rc_force" ${command} startall >/dev/null &
 }
 
 run_rc_command "$1"

--- a/vm
+++ b/vm
@@ -58,7 +58,8 @@ fi
 [ ${BSD_VERSION} -lt 1000000 ] && __err "please upgrade to FreeBSD 10 or newer for bhyve support"
 
 # we should be enabled in rc.conf
-if ! checkyesno vm_enable; then
+# or call it using forcestart
+if [ -z "$rc_force" ] && ! checkyesno vm_enable; then
     __err "\$vm_enable is not enabled in /etc/rc.conf!"
 fi
 


### PR DESCRIPTION
When rc.d script is called with forcestart parameter it should start
even if it's not defined in rc.conf. rc.subr sets rc_force=yes in this
case. Change rc.d script to pass along rc_force env var and respect it
when it's defined

Sponsored by: Rubicon Communications (Netgate)