### PR TITLE
_gw: force ipv4 flag for netstat to avoid duplicate interface gw output

### DIFF
--- a/lib/vm-switch
+++ b/lib/vm-switch
@@ -448,7 +448,7 @@ __switch_nat_init(){
     local _gw _bnum
 
     # get default gateway
-    _gw=$(netstat -rn | grep default | awk '{print $4}')
+    _gw=$(netstat -4rn | grep default | awk '{print $4}')
 
     # basic dnsmasq settings
     echo "# vm-bhyve dhcp" > /usr/local/etc/dnsmasq.conf.bhyve


### PR DESCRIPTION
currently:



root@dnxsys-hy004:/vm/.templates # cat /vm/.config/pf-nat.conf
\# vm-bhyve nat
nat on ix0
ix0 from {172.16.0.0/24} to any -> (ix0
ix0)

It is due to matching ipv4 and ipv6 gateway :

root@dnxsys-hy004:/vm/.templates # netstat -rn | grep default | awk '{print $4}'
ix0
ix0

Proposal:

root@dnxsys-hy004:/vm/.templates # netstat -4rn | grep default | awk '{print $4}'
ix0
