### PR TITLE
Fix a "printf: not completely converted" in some locales

### DIFF
--- a/lib/vm-info
+++ b/lib/vm-info
@@ -363,5 +363,6 @@ __vm_info_bytes_human(){
         5) _ext="T" ;;
     esac
 
+    export LC_NUMERIC="C"
     printf "%.3f%s" "${_val}" "${_ext}"
 }


### PR DESCRIPTION
In some locales, a sign of the separator operates a comma. printf uses a point as a separator. If you specify a locale in the code, you can avoid mistakes "printf: not completely converted"