### PR TITLE
Initial support for span port switch interfaces

### DIFF
--- a/lib/vm-run
+++ b/lib/vm-run
@@ -465,7 +465,7 @@ vm::bhyve_device_disks(){
 # @modifies _devices _slot _taplist
 #
 vm::bhyve_device_networking(){
-    local _type _switch _mac _custom_tap _tap _sid _mtu
+    local _type _switch _mac _custom_tap _tap _sid _mtu _span
     local _num=0
 
     while [ 1 ]; do
@@ -475,6 +475,7 @@ vm::bhyve_device_networking(){
         config::get "_switch" "network${_num}_switch"
         config::get "_mac" "network${_num}_mac"
         config::get "_custom_tap" "network${_num}_device"
+        config::get "_span" "network${_num}_span"
 
         # set a static mac if we don't have one
         [ -z "${_mac}" ] && vm::generate_static_mac
@@ -502,6 +503,13 @@ vm::bhyve_device_networking(){
                 _tap=$(ifconfig tap create)
             fi
 
+            # Select span or member type
+            if [ -n "${_span}" ]; then
+				_span="span"
+			else
+				_span="addm"
+			fi
+
             if [ -n "${_tap}" ]; then
                 util::log "guest" "${_name}" "initialising network device ${_tap}"
                 ifconfig "${_tap}" description "vmnet-${_name}-${_num}-${_switch:-custom}" >/dev/null 2>&1
@@ -517,8 +525,8 @@ vm::bhyve_device_networking(){
                     	    ifconfig "${_tap}" mtu "${_mtu}" >/dev/null 2>&1
                         fi
 
-                        util::log "guest" "${_name}" "adding ${_tap} -> ${_sid} (${_switch})"
-                        ifconfig "${_sid}" addm "${_tap}" >/dev/null 2>&1
+                        util::log "guest" "${_name}" "adding ${_tap} -> ${_sid} (${_switch} ${_span})"
+                        ifconfig "${_sid}" "${_span}" "${_tap}" >/dev/null 2>&1
                         [ $? -ne 0 ] && util::log "guest" "${_name}" "failed to add ${_tap} to ${_sid}"
                     else
                         util::log "guest" "${_name}" "failed to find virtual switch '${_switch}'"

--- a/sample-templates/config.sample
+++ b/sample-templates/config.sample
@@ -221,6 +221,14 @@ network0_device=""
 #
 network0_mac=""
 
+# network0_span
+# Set to any value other than [empty]/off/false/no/0 to create the specified
+# port as a SPAN port rather than as an ordinary bridge member.
+#
+# NOTE: Does not work with VALE switches yet.
+#
+network0_span="no"
+
 # passthru0
 # Add a pass-through PCI device to the virtual machine. This allows the guest
 # to access a hardware device no differently than if it was running on bare

--- a/vm.8
+++ b/vm.8
@@ -1056,6 +1056,11 @@ This option allows you to specify a mac address to use for this interface. If no
 provided,
 .Xr bhyve 8
 will generate a mac address.
+.It network0_span
+Set this option to
+.Sy yes
+to instruct vm-bhyve to add the virtual network interface to the switch as a span port 
+on the bridge.  The default is to add the port to the switch as an ordinary bridge member.
 .It disk0_type
 The emulation type for the first virtual disk. At least one virtual disk is required.
 Valid options for this are currently


### PR DESCRIPTION
Added new vm config option "network0_span" to control whether a tap is added to a switch as a span interface or as an ordinary bridge member (default).  This supports creation of security VMs intended to monitor network traffic.

Note that a similar feature was requested in #41.  Unfortunately, custom bridges cannot be used as suggested because on shutdown vm-bhyve deletes every tap interface belonging to the guest (including custom tap interfaces).  This makes it impossible to use this feature to create a persistent span port on a bridge.