### PR TITLE
Automatically fit column output using "column -t"

### DIFF
--- a/lib/vm-core
+++ b/lib/vm-core
@@ -35,6 +35,8 @@ core::list(){
     _our_host=$(hostname)
 
     vm::running_load
+
+    {
     printf "${_format}" "NAME" "DATASTORE" "LOADER" "CPU" "MEMORY" "VNC" "AUTOSTART" "STATE"
 
     for _ds in ${VM_DATASTORE_LIST}; do
@@ -80,12 +82,13 @@ core::list(){
             # if stopped, see if it's locked by another host
             if [ "${_run}" = "Stopped" -a -e "${VM_DS_PATH}/${_name}/run.lock" ]; then
                 _run=$(head -n1 "${VM_DS_PATH}/${_name}/run.lock")
-                _run="Locked (${_run})"
+                _run="Locked(${_run})"
             fi
 
             printf "${_format}" "${_name}" "${_ds}" "${_loader}" "${_cpu}" "${_memory}" "${_vnc}" "${_auto}" "${_run}"
         done
     done
+    } | column -t
 }
 
 # 'vm check name'

--- a/lib/vm-run
+++ b/lib/vm-run
@@ -779,14 +779,14 @@ vm::running_check(){
 
     for _entry in ${VM_RUN_BHYVE}; do
         if [ "${_entry##* }" = "${_name}" ]; then
-            setvar "${_var}" "Running (${_entry%% *})"
+            setvar "${_var}" "Running(${_entry%% *})"
             return 0
         fi
     done
 
     for _entry in ${VM_RUN_LOAD}; do
         if [ "${_entry##* }" = "${_name}" ]; then
-            setvar "${_var}" "Bootloader (${_entry%% *})"
+            setvar "${_var}" "Bootloader(${_entry%% *})"
             return 0
         fi
     done


### PR DESCRIPTION
A somewhat silly proposal - feel free to discard :)

I made a quick patch to format columns using the column(1) utility, to make the output more compact and fit an 80 column terminal most of the times. To make this work, I had to change strings like "Running (xxx)" to "Running(xxx)" - without the whitespace.

Caveats: datastore paths containing whitespace will mess up the columns (but it should be a very remote case I hope)

Output looks like this with the patch:

    NAME       DATASTORE  LOADER     CPU  MEMORY  VNC  AUTOSTART  STATE
    arch       default    grub       4    4G      -    No         Stopped
    c1         default    bhyveload  2    1G      -    No         Running(39026)
    c2         default    bhyveload  2    1G      -    No         Running(39057)
    c3         default    bhyveload  2    1G      -    No         Running(38952)
    coreos     default    grub       4    2G      -    No         Stopped
    freebsd11  default    bhyveload  4    4G      -    No         Stopped
    netbsd     default    grub       2    1024M   -    No         Stopped
    openbsd    default    grub       2    2G      -    No         Stopped

(pipe to column(1) is aligned to the while loop to minimize the diff)