### PR TITLE
Add sample template for Debian preseeded installations.

### DIFF
--- a/sample-templates/debian-preseed.conf
+++ b/sample-templates/debian-preseed.conf
@@ -1,0 +1,10 @@
+loader="grub"
+cpu=1
+memory=512M
+network0_type="virtio-net"
+network0_switch="public"
+disk0_type="ahci-hd"
+disk0_name="disk0.img"
+# Sample preseed file at https://www.debian.org/releases/[wheezy,jessie,...]/example-preseed.txt
+grub_install0="linux /install.amd/vmlinuz install auto=true priority=critical url=http://your.preseed.server/preseed.txt"
+grub_install1="initrd /install.amd/initrd.gz"


### PR DESCRIPTION
A quick trick to install Debian VMs without console interaction.
