### PR TITLE
Add dmesg to boot dependency

### DIFF
--- a/rc.d/vm
+++ b/rc.d/vm
@@ -3,7 +3,7 @@
 # $FreeBSD$
 
 # PROVIDE: vm
-# REQUIRE: NETWORKING SERVERS
+# REQUIRE: NETWORKING SERVERS dmesg
 # BEFORE: dnsmasq
 # KEYWORD: shutdown nojail
 


### PR DESCRIPTION
FreeBSD 11 shows `"grep: /var/run/dmesg.boot: No such file or directory"` error messages when booting. I tracked these down to the `util::check_bhyve_support` function in `lib/vm-util`. The function uses the contents of the `/var/run/dmesg.boot` file to check required CPU features.

But the `/var/run/dmesg.boot` file is only created when `/etc/rc.d/dmesg` runs during system boot and that may happen after vm-bhyve tries to start because there is no boot dependency specified.

This is a quick fix to add dmesg as boot dependency.

There is in fact a more profound problem: the file may not be created at all if the admin chooses to set `dmesg_enable="NO"` in `/etc/rc.conf`
