### PR TITLE
coreos: Use UEFI to boot from a disk

### DIFF
--- a/sample-templates/coreos.conf
+++ b/sample-templates/coreos.conf
@@ -1,4 +1,9 @@
-loader="grub"
+# Use GRUB when booting from an installation medium
+#loader="grub"
+
+# Use UEFI when booting from a disk
+uefi="yes"
+
 cpu=1
 memory=1024M
 network0_type="virtio-net"
@@ -7,4 +12,3 @@ disk0_type="virtio-blk"
 disk0_name="disk0.img"
 grub_install0="linux /coreos/vmlinuz coreos.autologin"
 grub_install1="initrd /coreos/cpio.gz"
-grub_run0="linux /coreos/vmlinuz-a ro root=LABEL=ROOT usr=LABEL=USR-A coreos.autologin"


### PR DESCRIPTION
CoreOS uses its own, modified version of GRUB to load the
appropriate vmlinuz image and mount the appropriate USR partition.
Not using it would leave you to change the boot command manually
everytime your installation performs an update.

On the other hand, CoreOS installation image is not EFI bootable
right now. So, if you want to install from the image, use GRUB
loader and revert back to using UEFI after installation is complete.