### PR TITLE
Fix variable quoting in zfs::init.

### DIFF
--- a/lib/vm-zfs
+++ b/lib/vm-zfs
@@ -45,7 +45,7 @@ zfs::init(){
 
     # check for zfs storage location
     # user should specify "zfs:pool/dataset" if they want ZFS support
-    if [ ${vm_dir%%:*} = "zfs" ]; then
+    if [ "${vm_dir%%:*}" = "zfs" ]; then
 
         # check zfs running
         kldstat -qm zfs >/dev/null 2>&1


### PR DESCRIPTION
In `zfs::init` there is this check:

    if [ ${vm_dir%%:*} = "zfs" ]; then

The left value must be quoted, or this warning will appear if `vm_dir` is not defined in `rc.conf`:

    [: =: unexpected operator
    ./vm: ERROR: $vm_dir has not been configured or is not a valid directory

With quoting, only the correct error message will be displayed.