### PR TITLE
Fix exit status for many vm commands

### DIFF
--- a/lib/vm-core
+++ b/lib/vm-core
@@ -151,7 +151,7 @@ core::create(){
     [ ! -d "${VM_DS_PATH}/${_name}" ] && util::err "unable to create virtual machine directory ${VM_DS_PATH}/${_name}"
 
     cp "${vm_dir}/.templates/${_template}.conf" "${VM_DS_PATH}/${_name}/${_name}.conf"
-    [ $? -ne 0 ] && util::err "unable to copy template to virtual machine directory"
+    [ $? -eq 0 ] || util::err "unable to copy template to virtual machine directory"
 
     # generate a uuid
     config::set "${_name}" "uuid" $(uuidgen)
@@ -173,7 +173,7 @@ core::create(){
                 ;;
             *)
                 truncate -s "${_disk_size}" "${VM_DS_PATH}/${_name}/${_disk}"
-                [ $? -ne 0 ] && util::err "failed to create sparse file for disk image"
+                [ $? -eq 0 ] || util::err "failed to create sparse file for disk image"
                 ;;
         esac
 
@@ -266,7 +266,7 @@ core::add_disk(){
             ;;
         file)
             truncate -s "${_size}" "${VM_DS_PATH}/${_name}/disk${_num}.img"
-            [ $? -ne 0 ] && util::err "failed to create sparse file for disk image"
+            [ $? -eq 0 ] || util::err "failed to create sparse file for disk image"
             _diskname="disk${_num}.img"
             ;;
         *)
@@ -278,7 +278,7 @@ core::add_disk(){
     config::set "${_name}" "disk${_num}_name" "${_diskname}"
     config::set "${_name}" "disk${_num}_type" "${_emulation}" "1"
     config::set "${_name}" "disk${_num}_dev" "${_device}" "1"
-    [ $? -ne 0 ] && util::err "disk image created but errors while updating guest configuration"
+    [ $? -eq 0 ] || util::err "disk image created but errors while updating guest configuration"
 }
 
 # add network interface to guest
@@ -309,7 +309,7 @@ core::add_network(){
     # update configuration
     config::set "${_name}" "network${_num}_type" "${_emulation}"
     config::set "${_name}" "network${_num}_switch" "${_switch}" "1"
-    [ $? -ne 0 ] && util::err "errors encountered while updating guest configuration"
+    [ $? -eq 0 ] || util::err "errors encountered while updating guest configuration"
 }
 
 # 'vm install'
@@ -404,7 +404,7 @@ core::__start(){
     # confirm we aren't running
     if ! vm::confirm_stopped "${_name}" "1" >/dev/null 2>&1; then
         echo "  ! guest appears to be running already"
-        return 1;
+        return 1
     fi
 
     # check basic settings before going into background mode
@@ -569,12 +569,12 @@ core::rename(){
     # rename folder if it still exists (shouldn't if zfs mode and rename worked)
     if [ -d "${VM_DS_PATH}/${_old}" ]; then
         mv "${VM_DS_PATH}/${_old}" "${VM_DS_PATH}/${_new}" >/dev/null 2>&1
-        [ $? -ne 0 ] && util::err "failed to rename guest directory"
+        [ $? -eq 0 ] || util::err "failed to rename guest directory"
     fi
 
     # rename config file
     mv "${VM_DS_PATH}/${_new}/${_old}.conf" "${VM_DS_PATH}/${_new}/${_new}.conf" >/dev/null 2>&1
-    [ $? -ne 0 ] && util::err "changed guest directory but failed to rename configuration file"
+    [ $? -eq 0 ] || util::err "changed guest directory but failed to rename configuration file"
 }
 
 # 'vm console'

--- a/lib/vm-datastore
+++ b/lib/vm-datastore
@@ -113,7 +113,7 @@ datastore::add(){
     # save
     config::core::set "datastore_list" "${_name}" "1"
     config::core::set "path_${_name}" "${_spec}"
-    [ $? -ne 0 ] && util::err "error saving settings to configuration file"
+    [ $? -eq 0 ] || util::err "error saving settings to configuration file"
 }
 
 # remove a datastore
@@ -136,7 +136,7 @@ datastore::remove(){
 
     config::core::remove "datastore_list" "${_name}"
     config::core::remove "path_${_name}"
-    [ $? -ne 0 ] && util::err "error removing settings from configuration file"
+    [ $? -eq 0 ] || util::err "error removing settings from configuration file"
 }
 
 # get the filesystem path for the specified dataset spec
@@ -290,7 +290,7 @@ datastore::iso(){
     # save
     config::core::set "datastore_list" "${_name}" "1"
     config::core::set "path_${_name}" "iso:${_path}"
-    [ $? -ne 0 ] && util::err "error saving settings to configuration file"
+    [ $? -eq 0 ] || util::err "error saving settings to configuration file"
 }
 
 # find an iso file by looking in the default location

--- a/lib/vm-migration
+++ b/lib/vm-migration
@@ -104,7 +104,7 @@ migration::__recv_snapshot(){
 
     echo "  * stage ${_stage}: waiting for snapshot on port ${_port}"
     socat -u "TCP-LISTEN:${_port}" EXEC:"zfs recv ${VM_DS_ZFS_DATASET}/${_name}" >/dev/null 2>&1
-    [ $? -ne 0 ] && util::err_inline "error detected while recieving snapshot"
+    [ $? -eq 0 ] || util::err_inline "error detected while recieving snapshot"
     echo "  * stage ${_stage}: complete"
 }
 
@@ -141,7 +141,7 @@ migration::send(){
 
     # split host & port
     echo "${_host}" | egrep -iqs '^.+:[0-9]+$'
-    [ $? -ne 0 ] && util::err "destination must be specified in host:port format"
+    [ $? -eq 0 ] || util::err "destination must be specified in host:port format"
     _port="${_host##*:}"
     _host="${_host%%:*}"
 
@@ -169,7 +169,7 @@ migration::send(){
         _snap1="$(date +'%Y%m%d%H%M%S')"
         echo "  * stage 1: taking snapshot - ${_snap1}"
         zfs snapshot -r "${VM_DS_ZFS_DATASET}/${_name}@${_snap1}" >/dev/null 2>&1
-        [ $? -ne 0 ] && util::err_inline "error taking snapshot"
+        [ $? -eq 0 ] || util::err_inline "error taking snapshot"
 
         # send the first snapshot
         migration::__send_snapshot "1" "${_snap1}" "${_inc}"
@@ -187,7 +187,7 @@ migration::send(){
         _snap2="$(date +'%Y%m%d%H%M%S')"
         echo "  * stage 1b: taking snapshot - ${_snap2}"
         zfs snapshot -r "${VM_DS_ZFS_DATASET}/${_name}@${_snap2}" >/dev/null 2>&1
-        [ $? -ne 0 ] && util::err_inline "error taking snapshot"
+        [ $? -eq 0 ] || util::err_inline "error taking snapshot"
 
         # send the middle snapshot
         migration::__send_snapshot "1b" "${_snap2}" "${_snap1}"
@@ -226,7 +226,7 @@ migration::send(){
     _snap3="$(date +'%Y%m%d%H%M%S')"
     echo "  * stage 2: taking snapshot - ${_snap3}"
     zfs snapshot -r "${VM_DS_ZFS_DATASET}/${_name}@${_snap3}" >/dev/null 2>&1
-    [ $? -ne 0 ] && util::err_inline "error taking snapshot"
+    [ $? -eq 0 ] || util::err_inline "error taking snapshot"
 
     # triple stage use snap 2
     # if single stage and snapshot given, use that
@@ -265,7 +265,7 @@ migration::__send_snapshot(){
         socat -u EXEC:"zfs send -R ${VM_DS_ZFS_DATASET}/${_name}@${_snapshot}" "TCP4:${_host}:${_port}" >/dev/null 2>&1
     fi
 
-    [ $? -ne 0 ] && util::err_inline "error detected while sending snapshot"
+    [ $? -eq 0 ] || util::err_inline "error detected while sending snapshot"
     echo "  * stage ${_stage}: complete"
 }
 

--- a/lib/vm-switch
+++ b/lib/vm-switch
@@ -116,20 +116,20 @@ switch::create(){
     # check vlan number
     if [ -n "${_vlan}" ]; then
         echo "${_vlan}" | egrep -qs '^[0-9]{1,4}$'
-        [ $? -ne 0 ] && util::err "invalid vlan number"
+        [ $? -eq 0 ] || util::err "invalid vlan number"
         [ ${_vlan} -ge 4095 ] && util::err "invalid vlan number"
     fi
 
     # check address
     if [ -n "${_addr}" ]; then
         echo "${_addr}" | egrep -qs '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\/[0-9]{1,2}$'
-        [ $? -ne 0 ] && util::err "address must be supplied in CIDR notation (a.b.c.d/prefix-len)"
+        [ $? -eq 0 ] || util::err "address must be supplied in CIDR notation (a.b.c.d/prefix-len)"
     fi
 
     # check mtu
     if [ -n "${_mtu}" ]; then
         echo "${_mtu}" | egrep -qs '^[0-9]{3,4}$'
-        [ $? -ne 0 ] && util::err "invalid mtu"
+        [ $? -eq 0 ] || util::err "invalid mtu"
         [ ${_mtu} -gt 9000 ] && util::err "invalid mtu"
     fi
 
@@ -240,7 +240,7 @@ switch::vlan(){
     [ -z "${_id}" ] && util:err "unable to locate specified virtual switch"
 
     echo "${_vlan}" | egrep -qs '^[0-9]{1,4}$'
-    [ $? -ne 0 ] && util::err "invalid vlan number"
+    [ $? -eq 0 ] || util::err "invalid vlan number"
     [ ${_vlan} -ge 4095 ] && util::err "invalid vlan number"
 
     case "${_type}" in

--- a/lib/vm-switch-standard
+++ b/lib/vm-switch-standard
@@ -37,7 +37,7 @@ switch::standard::init(){
 
     # create a bridge for this switch
     _id=$(ifconfig bridge create description "vm-${_name}" priority 0 up 2>/dev/null)
-    [ $? -ne 0 ] && util::err "failed to create bridge interface for switch ${_name}"
+    [ $? -eq 0 ] || util::err "failed to create bridge interface for switch ${_name}"
 
     # try to set ip address
     config::core::get "_addr" "addr_${_name}"
@@ -247,7 +247,7 @@ switch::standard::__configure_port(){
         # create if needed
         if [ -z "${_vid}" ]; then
             _vid=$(ifconfig vlan create vlandev "${_port}" vlan "${_vlan}" description "vm-vlan-${_port}-${_vlan}" up)
-            [ $? -ne 0 ] && util::err "failed to create vlan interface for port ${_port} on switch ${_switch}"
+            [ $? -eq 0 ] || util::err "failed to create vlan interface for port ${_port} on switch ${_switch}"
         fi
 
         ifconfig ${_id} addm ${_vid} >/dev/null 2>&1
@@ -256,7 +256,7 @@ switch::standard::__configure_port(){
         ifconfig ${_id} addm ${_port} >/dev/null 2>&1
     fi
 
-    [ $? -ne 0 ] && util::err "failed to add member ${_port} to the virtual switch ${_switch}"
+    [ $? -eq 0 ] || util::err "failed to add member ${_port} to the virtual switch ${_switch}"
 }
 
 # unconfigure a local port

--- a/lib/vm-switch-vxlan
+++ b/lib/vm-switch-vxlan
@@ -55,7 +55,7 @@ switch::vxlan::init(){
 
     # create a bridge for this switch
     _id=$(ifconfig bridge create description "vm-${_name}" up 2>/dev/null)
-    [ $? -ne 0 ] && util::err "failed to create bridge interface for switch ${_name}"
+    [ $? -eq 0 ] || util::err "failed to create bridge interface for switch ${_name}"
 
     # bridge vxlan to our guest switch
     # static route traffic for this multicast address via our specified interface

--- a/lib/vm-util
+++ b/lib/vm-util
@@ -44,7 +44,7 @@ util::load_module(){
     kldstat -qm ${_mod} >/dev/null 2>&1
     if [ $? -ne 0 ]; then
         kldload ${_mod} >/dev/null 2>&1
-        [ $? -ne 0 ] && util::err "unable to load ${_mod}.ko!"
+        [ $? -eq 0 ] || util::err "unable to load ${_mod}.ko!"
     fi
 }
 

--- a/lib/vm-zfs
+++ b/lib/vm-zfs
@@ -49,7 +49,7 @@ zfs::init(){
 
         # check zfs running
         kldstat -qm zfs >/dev/null 2>&1
-        [ $? -ne 0 ] && util::err "ZFS support requested but ZFS not available"
+        [ $? -eq 0 ] || util::err "ZFS support requested but ZFS not available"
 
         # global zfs details
         VM_ZFS="1"
@@ -74,7 +74,7 @@ zfs::make_dataset(){
     if [ -n "${_name}" -a "${VM_DS_ZFS}" = "1" ]; then
         zfs::__format_options "_opts" "${_opts}"
         zfs create ${_opts} "${_name}"
-        [ $? -ne 0 ] && util::err "failed to create new ZFS dataset ${_name}"
+        [ $? -eq 0 ] || util::err "failed to create new ZFS dataset ${_name}"
     fi
 }
 
@@ -87,7 +87,7 @@ zfs::destroy_dataset(){
 
     if [ -n "${_name}" -a "${VM_DS_ZFS}" = "1" ]; then
         zfs destroy -rf "${_name}" >/dev/null 2>&1
-        [ $? -ne 0 ] && util::err "failed to destroy ZFS dataset ${_name}"
+        [ $? -eq 0 ] || util::err "failed to destroy ZFS dataset ${_name}"
     fi
 }
 
@@ -104,7 +104,7 @@ zfs::rename_dataset(){
 
     if [ -n "${_old}" -a -n "${_new}" -a "${VM_DS_ZFS}" = "1" ]; then
         zfs rename "${VM_DS_ZFS_DATASET}/${_old}" "${VM_DS_ZFS_DATASET}/${_new}" >/dev/null 2>&1
-        [ $? -ne 0 ] && util::err "failed to rename ZFS dataset ${VM_DS_ZFS_DATASET}/${_old}"
+        [ $? -eq 0 ] || util::err "failed to rename ZFS dataset ${VM_DS_ZFS_DATASET}/${_old}"
     fi
 }
 
@@ -126,7 +126,7 @@ zfs::make_zvol(){
 
     zfs::__format_options "_user_opts" "${_user_opts}"
     zfs create ${_opt} ${_size} -o volmode=dev ${_user_opts} "${_name}"
-    [ $? -ne 0 ] && util::err "failed to create new ZVOL ${_name}"
+    [ $? -eq 0 ] || util::err "failed to create new ZVOL ${_name}"
 }
 
 # format options for zfs commands
@@ -189,7 +189,7 @@ zfs::snapshot(){
     fi
 
     zfs snapshot -r ${VM_DS_ZFS_DATASET}/${_name}@${_snap}
-    [ $? -ne 0 ] && util::err "failed to create recursive snapshot of virtual machine"
+    [ $? -eq 0 ] || util::err "failed to create recursive snapshot of virtual machine"
 }
 
 # 'vm rollback'
@@ -268,7 +268,7 @@ zfs::clone(){
 
     # get list of datasets to copy
     _fs_list=$(zfs list -rHo name -t filesystem,volume "${VM_DS_ZFS_DATASET}/${_old}")
-    [ $? -ne 0 ] && util::err "unable to list datasets for ${VM_DS_ZFS_DATASET}/${_old}"
+    [ $? -eq 0 ] || util::err "unable to list datasets for ${VM_DS_ZFS_DATASET}/${_old}"
 
     # generate a short uuid and create snapshot if no custom snap given
     if [ -z "${_snap}" ]; then
@@ -276,11 +276,11 @@ zfs::clone(){
         _snap=$(echo "${_uuid}" |awk -F- '{print $1}')
 
         zfs snapshot -r "${VM_DS_ZFS_DATASET}/${_old}@${_snap}"
-        [ $? -ne 0 ] && util::err "failed to create snapshot ${VM_DS_ZFS_DATASET}/${_old}@${_snap}"
+        [ $? -eq 0 ] || util::err "failed to create snapshot ${VM_DS_ZFS_DATASET}/${_old}@${_snap}"
     else
         for _fs in ${_fs_list}; do
             zfs get creation "${_fs}@${_snap}" >/dev/null 2>&1
-            [ $? -ne 0 ] && util::err "snapshot ${_fs}@${_snap} doesn't seem to exist"
+            [ $? -eq 0 ] || util::err "snapshot ${_fs}@${_snap} doesn't seem to exist"
         done
     fi
 
@@ -289,7 +289,7 @@ zfs::clone(){
         _newfs=$(echo "${_fs}" | sed "s@${VM_DS_ZFS_DATASET}/${_old}@${VM_DS_ZFS_DATASET}/${_name}@")
 
         zfs clone "${_fs}@${_snap}" "${_newfs}"
-        [ $? -ne 0 ] && util::err "error while cloning dataset ${_fs}@${_snap}"
+        [ $? -eq 0 ] || util::err "error while cloning dataset ${_fs}@${_snap}"
     done
 
     # update new guest files
@@ -350,12 +350,12 @@ zfs::image_create(){
     # create the image dataset if we don't have it
     if [ ! -e "${vm_dir}/images" ]; then
         zfs create "${VM_ZFS_DATASET}/images" >/dev/null 2>&1
-        [ $? -ne 0 ] && util::err "failed to create image store ${VM_ZFS_DATASET}/images"
+        [ $? -eq 0 ] || util::err "failed to create image store ${VM_ZFS_DATASET}/images"
     fi
 
     # try to snapshot
     zfs snapshot -r "${VM_DS_ZFS_DATASET}/${_name}@${_snap}" >/dev/null 2>&1
-    [ $? -ne 0 ] && util::err "failed to create snapshot of source dataset ${VM_DS_ZFS_DATASET}/${_name}@${_snap}"
+    [ $? -eq 0 ] || util::err "failed to create snapshot of source dataset ${VM_DS_ZFS_DATASET}/${_name}@${_snap}"
 
     # copy source
     if [ -n "${_no_compress}" ]; then
@@ -431,14 +431,14 @@ zfs::image_provision(){
     esac
 
     # error unpacking?
-    [ $? -ne 0 ] && util::err "errors occured while trying to unpackage the image file"
+    [ $? -eq 0 ] || util::err "errors occured while trying to unpackage the image file"
 
     # remove the original snapshot
     zfs destroy -r "${VM_DS_ZFS_DATASET}/${_name}@${_uuid%%-*}" >/dev/null 2>&1
 
     # rename the guest configuration file
     mv "${VM_DS_PATH}/${_name}/${_oldname}.conf" "${VM_DS_PATH}/${_name}/${_name}.conf" >/dev/null 2>&1
-    [ $? -ne 0 ] && util::err "unpackaged image but unable to update guest configuration file"
+    [ $? -eq 0 ] || util::err "unpackaged image but unable to update guest configuration file"
 
     # update mac addresses and create a new uuid
     _uuid=$(uuidgen)


### PR DESCRIPTION
The pattern "[ $? -ne 0 ] && util::err ..." is problematic since it
leaves an exit status of 1 if the test fails, which is the non-error
case. So various commands (e.g., vm datastore add) return status 1 even
when they succeed if this pattern appears as the last line of a command
implementation.

Fix this by mechanically converting the pattern to "[ $? -eq 0 ] || util:err ...".