### PR TITLE
Merge switch name limit to 1.2

### DIFF
--- a/lib/vm-core
+++ b/lib/vm-core
@@ -346,12 +346,76 @@ core::startall(){
 # note this will also stop instances not started by vm-bhyve
 #
 core::stopall(){
-    local _pids=$(pgrep -f 'bhyve:')
+    local _pids=$(pgrep -f 'bhyve:' | tr '\n' ' ')
+    local _stop_parallel _stop_list _running _list_rev _curr
+    local _stop_p_pids _pid
 
-    echo "Shutting down all bhyve virtual machines"
-    killall bhyve
-    sleep 1
-    killall bhyve
+    : ${vm_delay:=2}
+
+    # get a list of running bhyve instances
+    _running=$(pgrep -lf 'bhyve:' | cut -d" " -f3 | tr '\n' ' ')
+    [ -z "${_running}" ] && return 0
+
+    # do we have any guests to stop in order
+    if [ -z "${VM_OPT_FORCE}" -a -n "${vm_list}" ]; then
+        # reverse the configured start order
+        for _curr in ${vm_list}; do
+            _list_rev="${_curr} ${_list_rev}"
+        done
+
+        # go through each autostart guest
+        # if running add to stop list.
+        # we are searching in reverse start order, so should get an ordered shutdown
+        for _curr in ${_list_rev}; do
+            echo "${_running}" | grep -qs "${_curr} "
+
+            if [ $? -eq 0 ]; then
+                _stop_list="${_stop_list}${_stop_list:+ }${_curr}"
+            fi
+        done
+
+        # look for anything running that isn't in the ordered stop list
+        for _curr in ${_running}; do
+            echo "${_stop_list}" | grep -qs "${_curr}\b"
+            if [ $? -ne 0 ]; then
+                _stop_parallel="${_stop_parallel}${_stop_parallel:+ }${_curr}"
+                core::__getpid "_pid" "bhyve: ${_curr}\$"
+                [ $? -eq 0 ] && _stop_p_pids="${_stop_p_pids}${_stop_p_pids:+ }${_pid}"
+            fi
+        done
+    else
+        # nothing ordered, or a force shutdown
+        # just do everything at once
+        _stop_parallel="${_running}"
+        _stop_p_pids="${_pids}"
+    fi
+
+    echo "Beginning shutdown process"
+
+    # have any guests to stop in parallel
+    if [ -n "${_stop_p_pids}" ]; then
+        echo "  * parallel shutdown of non-ordered guests: ${_stop_parallel}"
+        kill ${_stop_p_pids} >/dev/null 2>&1
+        sleep 1
+        kill ${_stop_p_pids} >/dev/null 2>&1
+    fi
+
+    if [ -n "${_stop_list}" ]; then
+        _pid=""
+        for _curr in ${_stop_list}; do
+            [ -n "${_pid}" ] && echo "  * waiting ${vm_delay} second(s)" && sleep ${vm_delay}
+            core::__getpid "_pid" "bhyve: ${_curr}\$"
+
+            if [ $? -ne 0 ]; then
+                echo "  * stopping ${_curr}"
+                kill ${_pid} >/dev/null 2>&1
+                sleep 1
+                kill ${_pid} >/dev/null 2>&1
+            fi
+        done
+    fi
+
+    echo ""
     wait_for_pids ${_pids}
 }
 
@@ -365,7 +429,7 @@ core::start(){
     local _done
 
     [ -z "${_name}" ] && util::usage
-    : ${vm_delay:=5}
+    : ${vm_delay:=2}
 
     # disable foreground/interactive if we're starting more than one
     if [ $# -ge 2 ]; then
@@ -768,4 +832,20 @@ core::set(){
 #
 core::__valid_config_setting(){
     echo "${VM_CONFIG_USER}" | grep -iqs "${1};"
+}
+
+# __getpid
+# get a process id
+#
+# @param string _var variable to put pid into
+# @param string _proc process to look for
+#
+core::__getpid(){
+    local _var="$1"
+    local _proc="$2"
+    local _ret
+
+    _ret=$(pgrep -f "${_proc}")
+    [ $? -eq 0 ] || return 1
+    setvar "${_var}" "${_ret}"
 }

--- a/lib/vm-core
+++ b/lib/vm-core
@@ -92,15 +92,6 @@ core::list(){
     } | column -ts^
 }
 
-# 'vm check name'
-# check name of virtual machine
-#
-# @return int 0 if name is valid
-#
-core::check_name(){
-    echo "$1" | egrep -iqs '^[a-z0-9][.a-z0-9-]{0,30}[a-z0-9]$'
-}
-
 # 'vm create'
 # create a new virtual machine
 #
@@ -127,7 +118,7 @@ core::create(){
     [ -z "${_name}" ] && util::usage
 
     # check guest name
-    core::check_name "${_name}" || util::err "invalid virtual machine name - '${_name}'"
+    util::check_name "${_name}" || util::err "invalid virtual machine name - '${_name}'"
     datastore::get_guest "${_name}" && util::err "virtual machine already exists in ${VM_DS_PATH}/${_name}"
     datastore::get "${_ds}" || util::err "unable to load datastore - '${_ds}'"
 
@@ -379,7 +370,7 @@ core::stopall(){
             echo "${_stop_list}" | grep -qs "${_curr}\b"
             if [ $? -ne 0 ]; then
                 _stop_parallel="${_stop_parallel}${_stop_parallel:+ }${_curr}"
-                core::__getpid "_pid" "bhyve: ${_curr}\$"
+                util::getpid "_pid" "bhyve: ${_curr}\$"
                 [ $? -eq 0 ] && _stop_p_pids="${_stop_p_pids}${_stop_p_pids:+ }${_pid}"
             fi
         done
@@ -404,7 +395,7 @@ core::stopall(){
         _pid=""
         for _curr in ${_stop_list}; do
             [ -n "${_pid}" ] && echo "  * waiting ${vm_delay} second(s)" && sleep ${vm_delay}
-            core::__getpid "_pid" "bhyve: ${_curr}\$"
+            util::getpid "_pid" "bhyve: ${_curr}\$"
 
             if [ $? -ne 0 ]; then
                 echo "  * stopping ${_curr}"
@@ -650,7 +641,7 @@ core::rename(){
     local _new="$2"
 
     [ -z "${_old}" -o -z "${_new}" ] && util::usage
-    core::check_name "${_new}" || util::err "invalid virtual machine name - '${_name}'"
+    util::check_name "${_new}" || util::err "invalid virtual machine name - '${_name}'"
 
     datastore::get_guest "${_new}" && util::err "directory ${VM_DS_PATH}/${_new} already exists"
     datastore::get_guest "${_old}" || util::err "${_old} doesn't appear to be a valid virtual machine"
@@ -792,7 +783,7 @@ core::get(){
         done
     else
         while [ -n "${_var}" ]; do
-            if core::__valid_config_setting "${_var}"; then
+            if util::valid_config_setting "${_var}"; then
                 config::core::get "_val" "${_var}"
                 printf "${_format}" "${_var}" "${_val:--}"
             fi
@@ -814,7 +805,7 @@ core::set(){
         _key="${_pair%%=*}"
         _val="${_pair#*=}"
 
-        if core::__valid_config_setting "${_key}"; then
+        if util::valid_config_setting "${_key}"; then
             config::core::set "${_key}" "${_val}"
         else
             util::err "invalid configuration setting - '${_key}'"
@@ -823,29 +814,4 @@ core::set(){
         shift
         _pair="$1"
     done
-}
-
-# check if the specified string is a valid core configuration
-# setting that the user can change
-#
-# @param string the setting name to look for
-#
-core::__valid_config_setting(){
-    echo "${VM_CONFIG_USER}" | grep -iqs "${1};"
-}
-
-# __getpid
-# get a process id
-#
-# @param string _var variable to put pid into
-# @param string _proc process to look for
-#
-core::__getpid(){
-    local _var="$1"
-    local _proc="$2"
-    local _ret
-
-    _ret=$(pgrep -f "${_proc}")
-    [ $? -eq 0 ] || return 1
-    setvar "${_var}" "${_ret}"
 }

--- a/lib/vm-datastore
+++ b/lib/vm-datastore
@@ -88,7 +88,7 @@ datastore::add(){
     local _mount _num=0 _curr
 
     [ -z "${_name}" -o -z "${_spec}" ] && util::usage
-    core::check_name "${_name}" || util::err "invalid datastore name - '${_name}'"
+    util::check_name "${_name}" || util::err "invalid datastore name - '${_name}'"
 
     # check name not in use
     for _curr in ${VM_DATASTORE_LIST}; do
@@ -277,7 +277,7 @@ datastore::iso(){
     local _path="$2"
 
     [ -z "${_name}" -o -z "${_path}" ] && util::usage
-    core::check_name "${_name}" || util::err "invalid datastore name - '${_name}'"
+    util::check_name "${_name}" || util::err "invalid datastore name - '${_name}'"
 
     # check name not in use
     for _curr in ${VM_DATASTORE_LIST}; do

--- a/lib/vm-info
+++ b/lib/vm-info
@@ -31,7 +31,7 @@
 #
 info::guest(){
     local _name="$1"
-    local _bridge_list=$(ifconfig | grep ^bridge | cut -d: -f1)
+    local _bridge_list=$(ifconfig -g bridge)
     local _ds
 
     vm::running_load
@@ -304,7 +304,7 @@ info::guest_disks(){
         if [ -n "${_path}" ]; then
             case "${_dev}" in
                 file)
-                    _size=$(stat "${_path}" | cut -d' ' -f8)
+                    _size=$(stat -f%z "${_path}")
                     _used=$(du "${_path}" | awk '{print $1}')
                     _used=$((_used * 1024))
                     ;;

--- a/lib/vm-info
+++ b/lib/vm-info
@@ -31,7 +31,7 @@
 #
 info::guest(){
     local _name="$1"
-    local _bridge_list=$(ifconfig -g bridge)
+    local _bridge_list=$(ifconfig -g vm-switch)
     local _ds
 
     vm::running_load

--- a/lib/vm-migration
+++ b/lib/vm-migration
@@ -49,7 +49,7 @@ migration::recv(){
     _name="$1"
 
     [ -z "${_name}" ] && util::usage
-    core::check_name "${_name}" || util::err "invalid virtual machine name - '${_name}'"
+    util::check_name "${_name}" || util::err "invalid virtual machine name - '${_name}'"
     datastore::get "${_ds}" || util::err "unable to load datastore - '${_ds}'"
     [ -z "${VM_DS_ZFS}" ] && util::err "${_ds} datastore must be on ZFS to support migration"
     [ -n "${_stage}" -a -n "${_triple}" ] && util::err "single stage and triple stage are mutually exclusive"

--- a/lib/vm-run
+++ b/lib/vm-run
@@ -209,6 +209,7 @@ vm::run(){
                 _exit=15
                 break
             fi
+            sleep 1
         fi
 
         # set full iso path

--- a/lib/vm-run
+++ b/lib/vm-run
@@ -69,18 +69,19 @@ vm::run(){
     fi
 
     util::log_rotate "guest" "${_name}"
-    util::log "guest" "${_name}" "initialising"
-    util::log "guest" "${_name}" " [loader: ${_loader:-none}]"
-    util::log "guest" "${_name}" " [uefi: ${_uefi}]"
-    util::log "guest" "${_name}" " [cpu: ${_cpu}]"
-    util::log "guest" "${_name}" " [memory: ${_memory}]"
-    util::log "guest" "${_name}" " [hostbridge: ${_hostbridge}]"
-    util::log "guest" "${_name}" " [com ports: ${_comports}]"
-    util::log "guest" "${_name}" " [uuid: ${_uuid}]"
-    util::log "guest" "${_name}" " [utctime: ${_utc}]"
-    util::log "guest" "${_name}" " [debug mode: ${_debug}]"
-    util::log "guest" "${_name}" " [primary disk: ${_bootdisk}]"
-    util::log "guest" "${_name}" " [primary disk dev: ${_bootdisk_dev}]"
+    util::log "guest" "${_name}" \
+      "initialising" \
+      " [loader: ${_loader:-none}]" \
+      " [uefi: ${_uefi}]" \
+      " [cpu: ${_cpu}]" \
+      " [memory: ${_memory}]" \
+      " [hostbridge: ${_hostbridge}]" \
+      " [com ports: ${_comports}]" \
+      " [uuid: ${_uuid}]" \
+      " [utctime: ${_utc}]" \
+      " [debug mode: ${_debug}]" \
+      " [primary disk: ${_bootdisk}]" \
+      " [primary disk dev: ${_bootdisk_dev}]"
 
     # check basic settings
     if [ -z "${_cpu}" -o -z "${_memory}" -o -z "${_bootdisk}" ]; then
@@ -231,9 +232,9 @@ vm::run(){
             fi
         fi
 
-        util::log "guest" "${_name}" " [bhyve options: ${_opts}]"
-        util::log "guest" "${_name}" " [bhyve devices: ${_devices}]"
-        util::log "guest" "${_name}" " [bhyve console: ${_comstring}]"
+        util::log "guest" "${_name}" " [bhyve options: ${_opts}]" \
+          " [bhyve devices: ${_devices}]" \
+          " [bhyve console: ${_comstring}]"
         [ -n "${_iso_dev}" ] && util::log "guest" "${_name}" " [bhyve iso device: ${_iso_dev}]"
         util::log "guest" "${_name}" "starting bhyve (run ${_run})"
 

--- a/lib/vm-run
+++ b/lib/vm-run
@@ -536,7 +536,7 @@ vm::bhyve_device_networking(){
 
             if [ -n "${_tap}" ]; then
                 util::log "guest" "${_name}" "initialising network device ${_tap}"
-                ifconfig "${_tap}" description "vmnet-${_name}-${_num}-${_switch:-custom}" >/dev/null 2>&1
+                ifconfig "${_tap}" description "vmnet-${_name}-${_num}-${_switch:-custom}" group vm-port >/dev/null 2>&1
 
                 if [ -n "${_switch}" ]; then
                     switch::id "_sid" "${_switch}"

--- a/lib/vm-switch
+++ b/lib/vm-switch
@@ -344,11 +344,7 @@ switch::type(){
     local _switch="$2"
 
     [ -z "${_switch}" ] && return 1
-    config::core::get "${_var}" "type_${_switch}"
-
-    # old code didn't set a type
-    # assume standard if we didn't find a config setting
-    [ $? -ne 0 ] && setvar "${_var}" "standard"
+    config::core::get "${_var}" "type_${_switch}" "standard"
 }
 
 # check if a switch is configured for private members

--- a/lib/vm-switch
+++ b/lib/vm-switch
@@ -111,7 +111,7 @@ switch::create(){
     _switch="$1"
 
     # check for a valid switch name
-    core::check_name "${_switch}" || util::err "invalid switch name - '${_switch}'"
+    util::check_name "${_switch}" 10 || util::err "invalid switch name - '${_switch}'"
 
     # make sure it's not an existing name
     config::core::get "_list" "switch_list"

--- a/lib/vm-switch-manual
+++ b/lib/vm-switch-manual
@@ -39,7 +39,7 @@ switch::manual::init(){
 
     # don't rename custom bridges. user can set this in rc.conf
     # or just stick with bridgeX
-    ifconfig "${_bridge}" description "vm-${_name}" up >/dev/null 2>&1
+    ifconfig "${_bridge}" description "vm-${_name}" group vm-switch up >/dev/null 2>&1
 }
 
 # show the configuration details for a manual switch

--- a/lib/vm-switch-standard
+++ b/lib/vm-switch-standard
@@ -36,7 +36,7 @@ switch::standard::init(){
     switch::standard::id "_id" "${_name}" && return 0
 
     # create a bridge for this switch
-    ifconfig bridge create name "${_id}" up >/dev/null 2>&1
+    ifconfig bridge create name "${_id}" group vm-switch up >/dev/null 2>&1
     [ $? -eq 0 ] || util::err "failed to create bridge interface for switch ${_name}"
 
     # randomise mac if feature is available
@@ -272,7 +272,7 @@ switch::standard::__configure_port(){
 
         # create if needed
         if [ $? -ne 0 ]; then
-            _vid=$(ifconfig vlan create vlandev "${_port}" vlan "${_vlan}" name "vm-${_port}.${_vlan}" up)
+            _vid=$(ifconfig vlan create vlandev "${_port}" vlan "${_vlan}" name "vm-${_port}.${_vlan}" group vm-vlan up)
             [ $? -eq 0 ] || util::err "failed to create vlan interface for port ${_port} on switch ${_switch}"
         fi
 

--- a/lib/vm-switch-vxlan
+++ b/lib/vm-switch-vxlan
@@ -54,7 +54,7 @@ switch::vxlan::init(){
     [ $? -eq 0 ] || return 1
 
     # create a bridge for this switch
-    ifconfig bridge create name "${_id}" up >/dev/null 2>&1
+    ifconfig bridge create name "${_id}" group vm-switch up >/dev/null 2>&1
     [ $? -eq 0 ] || util::err "failed to create bridge interface for switch ${_name}"
 
     # randomise mac if feature is available

--- a/lib/vm-util
+++ b/lib/vm-util
@@ -270,16 +270,19 @@ util::log(){
     case "${_type}" in
         guest)
             _guest="$2"
-            _message="$3"
             _file="${VM_DS_PATH}/${_guest}/${_lf}"
+            shift 2
             ;;
         system)
-            _message="$2"
             _file="${vm_dir}/${_lf}"
+            shift 1
             ;;
     esac
 
-    echo "$(date +'%b %d %T'): ${_message}" >> "${_file}"
+    while [ -n "$1" ]; do
+      echo "$(date +'%b %d %T'): $1" >> "${_file}"
+      shift
+    done
 }
 
 # write content to a file, and log what we

--- a/lib/vm-util
+++ b/lib/vm-util
@@ -347,3 +347,43 @@ util::checkyesno(){
         *)  return 0 ;;		
     esac
 }
+
+# 'vm check name'
+# check name of virtual machine
+#
+# @param _name name to check
+# @param _maxlen=16 maximum name length (NOTE should be 2 less than desired)
+# @return int 0 if name is valid
+#
+util::check_name(){
+    local _name="$1"
+    local _maxlen="$2"
+
+    : ${_maxlen:=30}
+    echo "${_name}" | egrep -iqs "^[a-z0-9][.a-z0-9-]{0,${_maxlen}}[a-z0-9]\$"
+}
+
+# check if the specified string is a valid core configuration
+# setting that the user can change
+#
+# @param string the setting name to look for
+#
+util::valid_config_setting(){
+    echo "${VM_CONFIG_USER}" | grep -iqs "${1};"
+}
+
+# __getpid
+# get a process id
+#
+# @param string _var variable to put pid into
+# @param string _proc process to look for
+#
+util::getpid(){
+    local _var="$1"
+    local _proc="$2"
+    local _ret
+
+    _ret=$(pgrep -f "${_proc}")
+    [ $? -eq 0 ] || return 1
+    setvar "${_var}" "${_ret}"
+}

--- a/lib/vm-util
+++ b/lib/vm-util
@@ -243,7 +243,7 @@ util::log_rotate(){
     esac
 
     if [ -e "${_file}" ]; then
-        _size=$(stat "${_file}" | cut -d' ' -f8)
+        _size=$(stat -f %z "${_file}")
 
         if [ -n "${_size}" -a "${_size}" -ge 1048576 ]; then
             unlink "${_file}.0.gz" >/dev/null 2>&1

--- a/rc.d/vm
+++ b/rc.d/vm
@@ -19,7 +19,7 @@ load_rc_config $name
 
 command="/usr/local/sbin/${name}"
 start_cmd="${name}_start"
-stop_cmd="${command} stopall"
+stop_cmd="${command} -f stopall"
 
 vm_start()
 {

--- a/vm
+++ b/vm
@@ -25,7 +25,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 VERSION=1.3-devel
-VERSION_INT=103003
+VERSION_INT=103004
 VERSION_BSD=$(uname -K)
 PATH=${PATH}:/bin:/usr/bin:/usr/local/bin:/sbin:/usr/sbin:/usr/local/sbin
 

--- a/vm
+++ b/vm
@@ -24,8 +24,8 @@
 # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-VERSION=1.2-beta1
-VERSION_INT=102065
+VERSION=1.3-devel
+VERSION_INT=103001
 VERSION_BSD=$(uname -K)
 PATH=${PATH}:/bin:/usr/bin:/usr/local/bin:/sbin:/usr/sbin:/usr/local/sbin
 

--- a/vm
+++ b/vm
@@ -25,7 +25,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 VERSION=1.3-devel
-VERSION_INT=103002
+VERSION_INT=103003
 VERSION_BSD=$(uname -K)
 PATH=${PATH}:/bin:/usr/bin:/usr/local/bin:/sbin:/usr/sbin:/usr/local/sbin
 

--- a/vm
+++ b/vm
@@ -25,7 +25,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 VERSION=1.3-devel
-VERSION_INT=103004
+VERSION_INT=103005
 VERSION_BSD=$(uname -K)
 PATH=${PATH}:/bin:/usr/bin:/usr/local/bin:/sbin:/usr/sbin:/usr/local/sbin
 

--- a/vm
+++ b/vm
@@ -25,7 +25,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 VERSION=1.3-devel
-VERSION_INT=103001
+VERSION_INT=103002
 VERSION_BSD=$(uname -K)
 PATH=${PATH}:/bin:/usr/bin:/usr/local/bin:/sbin:/usr/sbin:/usr/local/sbin
 

--- a/vm.8
+++ b/vm.8
@@ -471,6 +471,8 @@ Create a new virtual switch.
 The name must be supplied and may only contain
 letters, numbers and dashes.
 However, it may not contain a dash at the beginning or end.
+Note that the maximum length of a switch name is also limited to
+12 characters, due to the way we use this as the interface name.
 .Pp
 There are currently 4 types of virtual switch that can be created.
 These are


### PR DESCRIPTION
Shame to limit switches to 12 characters but does make `ifconfig` output much cleaner for both users and vm-bhyve.

Will revert to using description field if shorter switch names causes problems