### PR TITLE
Add link to Windows wiki section

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Restart your vm.
 
 ## Windows Support
 
-Please see the Windows section in the [Wiki](https://github.com/churchers/vm-bhyve/wiki/Running-Windows-(Unattended-Install))
+Please see the Windows section in the [Wiki](https://github.com/churchers/vm-bhyve/wiki/Running-Windows)
 
 ## Autocomplete
 

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Restart your vm.
 
 ## Windows Support
 
-Please see the Windows section in the Wiki
+Please see the Windows section in the [Wiki](https://github.com/churchers/vm-bhyve/wiki/Running-Windows-(Unattended-Install))
 
 ## Autocomplete
 


### PR DESCRIPTION
The readme instructs users to look in the wiki for Windows guest related questions.
This commit adds a link in the readme to the wiki page mentioned.