### PR TITLE
VM Define

### DIFF
--- a/lib/vm-cmd
+++ b/lib/vm-cmd
@@ -24,13 +24,13 @@
 # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-CMD_VALID_LIST="init,switch,datastore,image,get,set,list,create,destroy,rename,install,start,stop,add"
+CMD_VALID_LIST="init,switch,datastore,image,get,set,list,define,create,destroy,rename,install,start,stop,add"
 CMD_VALID_LIST="${CMD_VALID_LIST},reset,poweroff,startall,stopall,console,iso,configure,passthru,_run"
 CMD_VALID_LIST="${CMD_VALID_LIST},info,clone,snapshot,rollback,send,recv,version,usage"
 
 # cmd: vm ...
 #
-# handle simple information commands that don't need any 
+# handle simple information commands that don't need any
 # priviledged access or bhyve support
 #
 # @param string _cmd the command right after 'vm '
@@ -68,6 +68,7 @@ cmd::parse(){
         get)       core::get "$@" ;;
         set)       core::set "$@" ;;
         list)      core::list ;;
+	define)    core::define "$@" ;;
         create)    core::create "$@" ;;
         destroy)   core::destroy "$@" ;;
         rename)    core::rename "$@" ;;

--- a/lib/vm-core
+++ b/lib/vm-core
@@ -77,7 +77,7 @@ core::list(){
                 # find out if we auto-start this vm, and get sequence number
                 for _vm in ${vm_list}; do
                     [ "${_vm}" = "${_name}" ] && _auto="Yes [${_num}]"
-                    _num=$((_num + 1))
+                    _num=$(($_num + 1))
                 done
 
                 # if stopped, see if it's locked by another host
@@ -90,6 +90,45 @@ core::list(){
             done
         done
     } | column -ts^
+}
+# 'vm define'
+# define a new virtual machine from template
+# @param string _template location of the template/config file
+core::define(){
+    local _template
+    local _name
+    local _disk_name _disk_dev _uuid
+    
+
+    if test "${1##*.}" = "conf"; # checking if a .conf file was passed as an argument.
+    then
+	_template=${1}
+        _name=$(echo "$1" | cut -d. -f1) # Getting virtual machine name from file name.
+    else
+	util::err "Template "*.conf" file is expected for defining a new guest!" 
+    fi
+    if [ ! -f "$_template" ]; then # checking if .conf file exists.
+	util::err "File does not exist!"
+    fi
+
+    config::load "$_template"
+    config::get "_disk_name" "disk0_name"
+    config::get "_disk_dev" "disk0_dev"
+    config::get "_uuid" "uuid"
+
+    datastore::get_guest "${_name}" && util::err "Failed to define guest domain from '$_template'. Virtual machine with name '$_name' already exists in ${vm_dir}/${_name}"
+    datastore::check_uuid_availability "${_uuid}" || util::err "Failed to define guest domain from '$_template'. Virtual machine with uuid '$_uuid' already exists in '${vm_dir}/${_uuid_taken_by}'."
+
+    #Checking if zfs volume exists when defining a new vm from teplate only when disk0_dev=custom
+    if test "$_disk_dev" = "custom"; then  
+           [ -e "$_disk_name" ] || util::err "Failed to define guest domain from '$_template'. ZFS volume name '$_disk_name' which was passed as disk0_name does not exist."
+    fi
+
+    [ ! -d "${vm_dir}/${_name}" ] && mkdir "${vm_dir}/${_name}" >/dev/null 2>&1
+    [ ! -d "${vm_dir}/${_name}" ] && util::err "unable to create virtual machine directory ${vm_dir}/${_name}"
+    cp $_template "${vm_dir}/${_name}/${_name}.conf"
+    [ $? -eq 0 ] || util::err "Failed to define guest domain from '$_template'. Unable to create virtual machine configuration file at '${vm_dir}/${_name}/'."
+
 }
 
 # 'vm create'
@@ -239,7 +278,7 @@ core::add_disk(){
     config::load "${VM_DS_PATH}/${_name}/${_name}.conf"
     config::get "_zfs_opts" "zfs_zvol_opts"
 
-    while true; do
+    while [ 1 ]; do
         config::get "_curr" "disk${_num}_name"
         [ -z "${_curr}" ] && break
         config::get "_emulation" "disk${_num}_type"
@@ -290,7 +329,7 @@ core::add_network(){
 
     config::load "${VM_DS_PATH}/${_name}/${_name}.conf"
 
-    while true; do
+    while [ 1 ]; do
         _emulation="${_curr}"
         config::get "_curr" "network${_num}_type"
         [ -z "${_curr}" ] && break
@@ -313,12 +352,9 @@ core::add_network(){
 # @param string _iso the iso file in $vm_dir/.iso to use
 #
 core::install(){
-    local _name _iso _fulliso
-
-    cmd::parse_args "$@"
-    shift $?
-    _name="$1"
-    _iso="$2"
+    local _name="$1"
+    local _iso="$2"
+    local _fulliso
 
     [ -z "${_name}" -o -z "${_iso}" ] && util::usage
 
@@ -340,77 +376,12 @@ core::startall(){
 # note this will also stop instances not started by vm-bhyve
 #
 core::stopall(){
-    local _pids=$(pgrep -f 'bhyve:' | tr '\n' ' ')
-    local _stop_parallel _stop_list _running _list_rev _curr
-    local _stop_p_pids _pid
+    local _pids=$(pgrep -f 'bhyve:')
 
-    cmd::parse_args "$@"
-    : ${vm_delay:=2}
-
-    # get a list of running bhyve instances
-    _running=$(pgrep -lf 'bhyve:' | cut -d" " -f3 | tr '\n' ' ')
-    [ -z "${_running}" ] && return 0
-
-    # do we have any guests to stop in order
-    if [ -z "${VM_OPT_FORCE}" -a -n "${vm_list}" ]; then
-        # reverse the configured start order
-        for _curr in ${vm_list}; do
-            _list_rev="${_curr} ${_list_rev}"
-        done
-
-        # go through each autostart guest
-        # if running add to stop list.
-        # we are searching in reverse start order, so should get an ordered shutdown
-        for _curr in ${_list_rev}; do
-            echo "${_running}" | grep -qs "${_curr} "
-
-            if [ $? -eq 0 ]; then
-                _stop_list="${_stop_list}${_stop_list:+ }${_curr}"
-            fi
-        done
-
-        # look for anything running that isn't in the ordered stop list
-        for _curr in ${_running}; do
-            echo "${_stop_list}" | grep -qs "${_curr}\b"
-            if [ $? -ne 0 ]; then
-                _stop_parallel="${_stop_parallel}${_stop_parallel:+ }${_curr}"
-                util::getpid "_pid" "bhyve: ${_curr}\$"
-                [ $? -eq 0 ] && _stop_p_pids="${_stop_p_pids}${_stop_p_pids:+ }${_pid}"
-            fi
-        done
-    else
-        # nothing ordered, or a force shutdown
-        # just do everything at once
-        _stop_parallel="${_running}"
-        _stop_p_pids="${_pids}"
-    fi
-
-    echo "Beginning shutdown process"
-
-    # have any guests to stop in parallel
-    if [ -n "${_stop_p_pids}" ]; then
-        echo "  * parallel shutdown of non-ordered guests: ${_stop_parallel}"
-        kill ${_stop_p_pids} >/dev/null 2>&1
-        sleep 1
-        kill ${_stop_p_pids} >/dev/null 2>&1
-    fi
-
-    if [ -n "${_stop_list}" ]; then
-        _pid=""
-        for _curr in ${_stop_list}; do
-            [ -n "${_pid}" ] && echo "  * waiting ${vm_delay} second(s)" && sleep ${vm_delay}
-            util::getpid "_pid" "bhyve: ${_curr}\$"
-
-            if [ $? -ne 0 ]; then
-                echo "  * stopping ${_curr}"
-                kill ${_pid} >/dev/null 2>&1
-                sleep 1
-                kill ${_pid} >/dev/null 2>&1
-            fi
-        done
-    fi
-
-    echo ""
+    echo "Shutting down all bhyve virtual machines"
+    killall bhyve
+    sleep 1
+    killall bhyve
     wait_for_pids ${_pids}
 }
 
@@ -420,15 +391,11 @@ core::stopall(){
 # @param string[multiple] _name the name of the guest(s) to start
 #
 core::start(){
-    local _name
+    local _name="$1"
     local _done
 
-    cmd::parse_args "$@"
-    shift $?
-    _name="$1"
-
     [ -z "${_name}" ] && util::usage
-    : ${vm_delay:=2}
+    : ${vm_delay:=5}
 
     # disable foreground/interactive if we're starting more than one
     if [ $# -ge 2 ]; then
@@ -517,7 +484,7 @@ core::__start(){
     # run background process to actually start bhyve
     # this will run as long as vm is running, including restarting bhyve after guest reboot
     if [ -n "${VM_OPT_FOREGROUND}" ]; then
-        $0 _run -f "${_name}" "${_iso}"
+        $0 -f _run "${_name}" "${_iso}"
     elif [ "${_console}" = "tmux" ]; then
         # can't have dots in tmux session :( (looks like it may use . to separate window.pane)
         # use ~ which we don't normally allow
@@ -525,9 +492,9 @@ core::__start(){
 
         # start session and connect if in interactive mode
         if [ -n "${VM_OPT_INTERACTIVE}" ]; then
-            ${_tmux_cmd} new -s "${_tmux_name}" $0 _run -tf "${_name}" "${_iso}"
+            ${_tmux_cmd} new -s "${_tmux_name}" $0 -tf _run "${_name}" "${_iso}"
         else
-            ${_tmux_cmd} new -ds "${_tmux_name}" $0 _run -tf "${_name}" "${_iso}"
+            ${_tmux_cmd} new -ds "${_tmux_name}" $0 -tf _run "${_name}" "${_iso}"
         fi
     else
         $0 _run "${_name}" "${_iso}" >/dev/null 2>&1 &
@@ -578,11 +545,7 @@ core::stop(){
 # @param string _name name of the guest
 #
 core::reset(){
-    local _name
-
-    cmd::parse_args "$@"
-    shift $?
-    _name="$1"
+    local _name="$1"
 
     [ -z "${_name}" ] && util::usage
     [ ! -e "/dev/vmm/${_name}" ] && util::err "${_name} doesn't appear to be a running virtual machine"
@@ -600,11 +563,7 @@ core::reset(){
 # @param string _name name of the guest
 #
 core::poweroff(){
-    local _name
-
-    cmd::parse_args "$@"
-    shift $?
-    _name="$1"
+    local _name="$1"
 
     [ -z "${_name}" ] && util::usage
     [ ! -e "/dev/vmm/${_name}" ] && util::err "${_name} doesn't appear to be a running virtual machine"
@@ -622,11 +581,7 @@ core::poweroff(){
 # @param string _name name of the guest
 #
 core::destroy(){
-    local _name
-
-    cmd::parse_args "$@"
-    shift $?
-    _name="$1"
+    local _name="$1"
 
     [ -z "${_name}" ] && util::usage
 
@@ -646,8 +601,8 @@ core::destroy(){
         util::confirm "Are you sure you want to completely remove this virtual machine" || exit 0
     fi
 
-    zfs::destroy_dataset "${VM_DS_ZFS_DATASET:?}/${_name:?}"
-    [ -e "${VM_DS_PATH}/${_name}" ] && rm -R "${VM_DS_PATH:?}/${_name:?}"
+    zfs::destroy_dataset "${VM_DS_ZFS_DATASET}/${_name}"
+    [ -e "${VM_DS_PATH}/${_name}" ] && rm -R "${VM_DS_PATH}/${_name}"
 }
 
 # 'vm rename'
@@ -741,7 +696,7 @@ core::configure(){
     local _name="$1"
 
     [ -z "${_name}" ] && util::usage
-    [ -z "${EDITOR}" ] && EDITOR="vi"
+    [ -z "${EDITOR}" ] && EDITOR=vi
 
     datastore::get_guest "${_name}" || \
         util::err "cannot locate configuration file for virtual machine: ${_name}"
@@ -803,7 +758,7 @@ core::get(){
         done
     else
         while [ -n "${_var}" ]; do
-            if util::valid_config_setting "${_var}"; then
+            if core::__valid_config_setting "${_var}"; then
                 config::core::get "_val" "${_var}"
                 printf "${_format}" "${_var}" "${_val:--}"
             fi
@@ -825,7 +780,7 @@ core::set(){
         _key="${_pair%%=*}"
         _val="${_pair#*=}"
 
-        if util::valid_config_setting "${_key}"; then
+        if core::__valid_config_setting "${_key}"; then
             config::core::set "${_key}" "${_val}"
         else
             util::err "invalid configuration setting - '${_key}'"
@@ -834,4 +789,15 @@ core::set(){
         shift
         _pair="$1"
     done
+}
+
+# check if the specified string is a valid core configuration
+# setting that the user can change
+#
+# @param string the setting name to look for
+#
+
+
+core::__valid_config_setting(){
+    echo "${VM_CONFIG_USER}" | grep -iqs "${1};"
 }

--- a/lib/vm-core
+++ b/lib/vm-core
@@ -77,7 +77,7 @@ core::list(){
                 # find out if we auto-start this vm, and get sequence number
                 for _vm in ${vm_list}; do
                     [ "${_vm}" = "${_name}" ] && _auto="Yes [${_num}]"
-                    _num=$(($_num + 1))
+                    _num=$((_num + 1))
                 done
 
                 # if stopped, see if it's locked by another host
@@ -90,45 +90,6 @@ core::list(){
             done
         done
     } | column -ts^
-}
-# 'vm define'
-# define a new virtual machine from template
-# @param string _template location of the template/config file
-core::define(){
-    local _template
-    local _name
-    local _disk_name _disk_dev _uuid
-    
-
-    if test "${1##*.}" = "conf"; # checking if a .conf file was passed as an argument.
-    then
-	_template=${1}
-        _name=$(echo "$1" | cut -d. -f1) # Getting virtual machine name from file name.
-    else
-	util::err "Template "*.conf" file is expected for defining a new guest!" 
-    fi
-    if [ ! -f "$_template" ]; then # checking if .conf file exists.
-	util::err "File does not exist!"
-    fi
-
-    config::load "$_template"
-    config::get "_disk_name" "disk0_name"
-    config::get "_disk_dev" "disk0_dev"
-    config::get "_uuid" "uuid"
-
-    datastore::get_guest "${_name}" && util::err "Failed to define guest domain from '$_template'. Virtual machine with name '$_name' already exists in ${vm_dir}/${_name}"
-    datastore::check_uuid_availability "${_uuid}" || util::err "Failed to define guest domain from '$_template'. Virtual machine with uuid '$_uuid' already exists in '${vm_dir}/${_uuid_taken_by}'."
-
-    #Checking if zfs volume exists when defining a new vm from teplate only when disk0_dev=custom
-    if test "$_disk_dev" = "custom"; then  
-           [ -e "$_disk_name" ] || util::err "Failed to define guest domain from '$_template'. ZFS volume name '$_disk_name' which was passed as disk0_name does not exist."
-    fi
-
-    [ ! -d "${vm_dir}/${_name}" ] && mkdir "${vm_dir}/${_name}" >/dev/null 2>&1
-    [ ! -d "${vm_dir}/${_name}" ] && util::err "unable to create virtual machine directory ${vm_dir}/${_name}"
-    cp $_template "${vm_dir}/${_name}/${_name}.conf"
-    [ $? -eq 0 ] || util::err "Failed to define guest domain from '$_template'. Unable to create virtual machine configuration file at '${vm_dir}/${_name}/'."
-
 }
 
 # 'vm create'
@@ -278,7 +239,7 @@ core::add_disk(){
     config::load "${VM_DS_PATH}/${_name}/${_name}.conf"
     config::get "_zfs_opts" "zfs_zvol_opts"
 
-    while [ 1 ]; do
+    while true; do
         config::get "_curr" "disk${_num}_name"
         [ -z "${_curr}" ] && break
         config::get "_emulation" "disk${_num}_type"
@@ -329,7 +290,7 @@ core::add_network(){
 
     config::load "${VM_DS_PATH}/${_name}/${_name}.conf"
 
-    while [ 1 ]; do
+    while true; do
         _emulation="${_curr}"
         config::get "_curr" "network${_num}_type"
         [ -z "${_curr}" ] && break
@@ -352,9 +313,12 @@ core::add_network(){
 # @param string _iso the iso file in $vm_dir/.iso to use
 #
 core::install(){
-    local _name="$1"
-    local _iso="$2"
-    local _fulliso
+    local _name _iso _fulliso
+
+    cmd::parse_args "$@"
+    shift $?
+    _name="$1"
+    _iso="$2"
 
     [ -z "${_name}" -o -z "${_iso}" ] && util::usage
 
@@ -376,12 +340,77 @@ core::startall(){
 # note this will also stop instances not started by vm-bhyve
 #
 core::stopall(){
-    local _pids=$(pgrep -f 'bhyve:')
+    local _pids=$(pgrep -f 'bhyve:' | tr '\n' ' ')
+    local _stop_parallel _stop_list _running _list_rev _curr
+    local _stop_p_pids _pid
 
-    echo "Shutting down all bhyve virtual machines"
-    killall bhyve
-    sleep 1
-    killall bhyve
+    cmd::parse_args "$@"
+    : ${vm_delay:=2}
+
+    # get a list of running bhyve instances
+    _running=$(pgrep -lf 'bhyve:' | cut -d" " -f3 | tr '\n' ' ')
+    [ -z "${_running}" ] && return 0
+
+    # do we have any guests to stop in order
+    if [ -z "${VM_OPT_FORCE}" -a -n "${vm_list}" ]; then
+        # reverse the configured start order
+        for _curr in ${vm_list}; do
+            _list_rev="${_curr} ${_list_rev}"
+        done
+
+        # go through each autostart guest
+        # if running add to stop list.
+        # we are searching in reverse start order, so should get an ordered shutdown
+        for _curr in ${_list_rev}; do
+            echo "${_running}" | grep -qs "${_curr} "
+
+            if [ $? -eq 0 ]; then
+                _stop_list="${_stop_list}${_stop_list:+ }${_curr}"
+            fi
+        done
+
+        # look for anything running that isn't in the ordered stop list
+        for _curr in ${_running}; do
+            echo "${_stop_list}" | grep -qs "${_curr}\b"
+            if [ $? -ne 0 ]; then
+                _stop_parallel="${_stop_parallel}${_stop_parallel:+ }${_curr}"
+                util::getpid "_pid" "bhyve: ${_curr}\$"
+                [ $? -eq 0 ] && _stop_p_pids="${_stop_p_pids}${_stop_p_pids:+ }${_pid}"
+            fi
+        done
+    else
+        # nothing ordered, or a force shutdown
+        # just do everything at once
+        _stop_parallel="${_running}"
+        _stop_p_pids="${_pids}"
+    fi
+
+    echo "Beginning shutdown process"
+
+    # have any guests to stop in parallel
+    if [ -n "${_stop_p_pids}" ]; then
+        echo "  * parallel shutdown of non-ordered guests: ${_stop_parallel}"
+        kill ${_stop_p_pids} >/dev/null 2>&1
+        sleep 1
+        kill ${_stop_p_pids} >/dev/null 2>&1
+    fi
+
+    if [ -n "${_stop_list}" ]; then
+        _pid=""
+        for _curr in ${_stop_list}; do
+            [ -n "${_pid}" ] && echo "  * waiting ${vm_delay} second(s)" && sleep ${vm_delay}
+            util::getpid "_pid" "bhyve: ${_curr}\$"
+
+            if [ $? -ne 0 ]; then
+                echo "  * stopping ${_curr}"
+                kill ${_pid} >/dev/null 2>&1
+                sleep 1
+                kill ${_pid} >/dev/null 2>&1
+            fi
+        done
+    fi
+
+    echo ""
     wait_for_pids ${_pids}
 }
 
@@ -391,11 +420,15 @@ core::stopall(){
 # @param string[multiple] _name the name of the guest(s) to start
 #
 core::start(){
-    local _name="$1"
+    local _name
     local _done
 
+    cmd::parse_args "$@"
+    shift $?
+    _name="$1"
+
     [ -z "${_name}" ] && util::usage
-    : ${vm_delay:=5}
+    : ${vm_delay:=2}
 
     # disable foreground/interactive if we're starting more than one
     if [ $# -ge 2 ]; then
@@ -484,7 +517,7 @@ core::__start(){
     # run background process to actually start bhyve
     # this will run as long as vm is running, including restarting bhyve after guest reboot
     if [ -n "${VM_OPT_FOREGROUND}" ]; then
-        $0 -f _run "${_name}" "${_iso}"
+        $0 _run -f "${_name}" "${_iso}"
     elif [ "${_console}" = "tmux" ]; then
         # can't have dots in tmux session :( (looks like it may use . to separate window.pane)
         # use ~ which we don't normally allow
@@ -492,9 +525,9 @@ core::__start(){
 
         # start session and connect if in interactive mode
         if [ -n "${VM_OPT_INTERACTIVE}" ]; then
-            ${_tmux_cmd} new -s "${_tmux_name}" $0 -tf _run "${_name}" "${_iso}"
+            ${_tmux_cmd} new -s "${_tmux_name}" $0 _run -tf "${_name}" "${_iso}"
         else
-            ${_tmux_cmd} new -ds "${_tmux_name}" $0 -tf _run "${_name}" "${_iso}"
+            ${_tmux_cmd} new -ds "${_tmux_name}" $0 _run -tf "${_name}" "${_iso}"
         fi
     else
         $0 _run "${_name}" "${_iso}" >/dev/null 2>&1 &
@@ -545,7 +578,11 @@ core::stop(){
 # @param string _name name of the guest
 #
 core::reset(){
-    local _name="$1"
+    local _name
+
+    cmd::parse_args "$@"
+    shift $?
+    _name="$1"
 
     [ -z "${_name}" ] && util::usage
     [ ! -e "/dev/vmm/${_name}" ] && util::err "${_name} doesn't appear to be a running virtual machine"
@@ -563,7 +600,11 @@ core::reset(){
 # @param string _name name of the guest
 #
 core::poweroff(){
-    local _name="$1"
+    local _name
+
+    cmd::parse_args "$@"
+    shift $?
+    _name="$1"
 
     [ -z "${_name}" ] && util::usage
     [ ! -e "/dev/vmm/${_name}" ] && util::err "${_name} doesn't appear to be a running virtual machine"
@@ -581,7 +622,11 @@ core::poweroff(){
 # @param string _name name of the guest
 #
 core::destroy(){
-    local _name="$1"
+    local _name
+
+    cmd::parse_args "$@"
+    shift $?
+    _name="$1"
 
     [ -z "${_name}" ] && util::usage
 
@@ -601,8 +646,8 @@ core::destroy(){
         util::confirm "Are you sure you want to completely remove this virtual machine" || exit 0
     fi
 
-    zfs::destroy_dataset "${VM_DS_ZFS_DATASET}/${_name}"
-    [ -e "${VM_DS_PATH}/${_name}" ] && rm -R "${VM_DS_PATH}/${_name}"
+    zfs::destroy_dataset "${VM_DS_ZFS_DATASET:?}/${_name:?}"
+    [ -e "${VM_DS_PATH}/${_name}" ] && rm -R "${VM_DS_PATH:?}/${_name:?}"
 }
 
 # 'vm rename'
@@ -696,7 +741,7 @@ core::configure(){
     local _name="$1"
 
     [ -z "${_name}" ] && util::usage
-    [ -z "${EDITOR}" ] && EDITOR=vi
+    [ -z "${EDITOR}" ] && EDITOR="vi"
 
     datastore::get_guest "${_name}" || \
         util::err "cannot locate configuration file for virtual machine: ${_name}"
@@ -758,7 +803,7 @@ core::get(){
         done
     else
         while [ -n "${_var}" ]; do
-            if core::__valid_config_setting "${_var}"; then
+            if util::valid_config_setting "${_var}"; then
                 config::core::get "_val" "${_var}"
                 printf "${_format}" "${_var}" "${_val:--}"
             fi
@@ -780,7 +825,7 @@ core::set(){
         _key="${_pair%%=*}"
         _val="${_pair#*=}"
 
-        if core::__valid_config_setting "${_key}"; then
+        if util::valid_config_setting "${_key}"; then
             config::core::set "${_key}" "${_val}"
         else
             util::err "invalid configuration setting - '${_key}'"
@@ -789,15 +834,4 @@ core::set(){
         shift
         _pair="$1"
     done
-}
-
-# check if the specified string is a valid core configuration
-# setting that the user can change
-#
-# @param string the setting name to look for
-#
-
-
-core::__valid_config_setting(){
-    echo "${VM_CONFIG_USER}" | grep -iqs "${1};"
 }

--- a/lib/vm-core
+++ b/lib/vm-core
@@ -92,6 +92,45 @@ core::list(){
     } | column -ts^
 }
 
+# 'vm define'
+# define a new virtual machine from template
+# @param string _template location of the template/config file
+core::define(){
+    local _template
+    local _name
+    local _disk_name _disk_dev _uuid
+
+    if test "${1##*.}" = "conf"; # checking if a .conf file was passed as an argument.
+    then
+        _template=${1}
+        _name=$(echo "$1" | cut -d. -f1) # Getting virtual machine name from file name.
+    else
+        util::err "Template "*.conf" file is expected for defining a new guest!"
+    fi
+    if [ ! -f "$_template" ]; then # checking if .conf file exists.
+        util::err "File does not exist!"
+    fi
+
+    config::load "$_template"
+    config::get "_disk_name" "disk0_name"
+    config::get "_disk_dev" "disk0_dev"
+    config::get "_uuid" "uuid"
+
+    datastore::get_guest "${_name}" && util::err "Failed to define guest domain from '$_template'. Virtual machine with name '$_name' already exists in ${vm_dir}/${_name}"
+    datastore::check_uuid_availability "${_uuid}" || util::err "Failed to define guest domain from '$_template'. Virtual machine with uuid '$_uuid' already exists in '${vm_dir}/${_uuid_taken_by}'."
+
+    #Checking if zfs volume exists when defining a new vm from teplate only when disk0_dev=custom
+    if test "$_disk_dev" = "custom"; then
+           [ -e "$_disk_name" ] || util::err "Failed to define guest domain from '$_template'. ZFS volume name '$_disk_name' which was passed as disk0_name does not exist."
+    fi
+
+    [ ! -d "${vm_dir}/${_name}" ] && mkdir "${vm_dir}/${_name}" >/dev/null 2>&1
+    [ ! -d "${vm_dir}/${_name}" ] && util::err "unable to create virtual machine directory ${vm_dir}/${_name}"
+    cp $_template "${vm_dir}/${_name}/${_name}.conf"
+    [ $? -eq 0 ] || util::err "Failed to define guest domain from '$_template'. Unable to create virtual machine configuration file at '${vm_dir}/${_name}/'."
+
+}
+
 # 'vm create'
 # create a new virtual machine
 #

--- a/lib/vm-datastore
+++ b/lib/vm-datastore
@@ -230,27 +230,6 @@ datastore::get_guest(){
     VM_DS_ZFS="${_zfs}"
     VM_DS_ZFS_DATASET="${_dataset}"
 }
-# Gets an uuid and checks if it's available or not
-# @param uuid
-# @return non-zero on unavailable uuid and sets _uuid_taken_by
-# @return 
-datastore::check_uuid_availability()
-{
-	local _taken_uuids _taken_uuid
-	_uuid_to_check=$1
-	
-	_taken_uuids=$(grep -iR "uuid" $vm_dir | grep ".conf" | grep -v ".templates" | cut -d= -f2 | tr -d '"') #Getting uuid for all currently defined machines.
-
-	for _taken_uuid in ${_taken_uuids}; do    
-   	if test "$_uuid_to_check" = "$_taken_uuid"; then
-               _uuid_taken_by=$(grep -iR "$_taken_uuid" /storage/vm | grep ".conf" | cut -d. -f1 | rev | cut -d/ -f1 | rev) # Getting the name of the guest which uses this uuid. 
-		return 1
-	fi
-	done
-
-
-}
-
 
 # get the path and details for a datastore
 # put into same variables as datastore_get_guest

--- a/lib/vm-datastore
+++ b/lib/vm-datastore
@@ -231,6 +231,26 @@ datastore::get_guest(){
     VM_DS_ZFS_DATASET="${_dataset}"
 }
 
+# Gets an uuid and checks if it's available or not
+# @param uuid
+# @return non-zero on unavailable uuid and sets _uuid_taken_by
+datastore::check_uuid_availability()
+{
+        local _taken_uuids _taken_uuid
+        _uuid_to_check=$1
+
+        _taken_uuids=$(grep -iR "uuid" $vm_dir | grep ".conf" | grep -v ".templates" | cut -d= -f2 | tr -d '"') #Getting uuid for all currently defined machines.
+
+        for _taken_uuid in ${_taken_uuids}; do
+        if test "$_uuid_to_check" = "$_taken_uuid"; then
+               _uuid_taken_by=$(grep -iR "$_taken_uuid" /storage/vm | grep ".conf" | cut -d. -f1 | rev | cut -d/ -f1 | rev) # Getting the name of the guest which uses this uuid.
+                return 1
+        fi
+        done
+
+}
+
+
 # get the path and details for a datastore
 # put into same variables as datastore_get_guest
 #

--- a/lib/vm-datastore
+++ b/lib/vm-datastore
@@ -230,6 +230,27 @@ datastore::get_guest(){
     VM_DS_ZFS="${_zfs}"
     VM_DS_ZFS_DATASET="${_dataset}"
 }
+# Gets an uuid and checks if it's available or not
+# @param uuid
+# @return non-zero on unavailable uuid and sets _uuid_taken_by
+# @return 
+datastore::check_uuid_availability()
+{
+	local _taken_uuids _taken_uuid
+	_uuid_to_check=$1
+	
+	_taken_uuids=$(grep -iR "uuid" $vm_dir | grep ".conf" | grep -v ".templates" | cut -d= -f2 | tr -d '"') #Getting uuid for all currently defined machines.
+
+	for _taken_uuid in ${_taken_uuids}; do    
+   	if test "$_uuid_to_check" = "$_taken_uuid"; then
+               _uuid_taken_by=$(grep -iR "$_taken_uuid" /storage/vm | grep ".conf" | cut -d. -f1 | rev | cut -d/ -f1 | rev) # Getting the name of the guest which uses this uuid. 
+		return 1
+	fi
+	done
+
+
+}
+
 
 # get the path and details for a datastore
 # put into same variables as datastore_get_guest

--- a/lib/vm-util
+++ b/lib/vm-util
@@ -27,7 +27,6 @@
 # make sure we have the right environment
 #
 util::setup(){
-    util::load_module "vmm"
     util::load_module "nmdm"
     util::load_module "if_bridge"
     util::load_module "if_tap"
@@ -55,47 +54,30 @@ util::load_module(){
 }
 
 # check if system have bhyve support
-# we look for POPCNT feature which is required
-# and should be listed on both Intel & AMD systems
+# look for sysctls set by the vmm module. I can't get confirmation that this
+# is a valid way to check vmm is working, even though it seems reasonable.
+# the vm_disable_host_checks="yes" rc settings allows bypassing all this
+# if your system should be supported but these checks break.
 # 
 # @modifies VM_NO_UG
 #
 util::check_bhyve_support(){
-    local _mesg _mesg1 _mesg2 _result
 
-    # basic checks
+    # almost all our functionality requires access to things only root can do
     [ `id -u` -ne 0 ] && util::err "virtual machines can only be managed by root"
-    [ ${VERSION_BSD} -lt 1000000 ] && util::err "please upgrade to FreeBSD 10 or newer for bhyve support"
 
-    # can't check any further if we don't have a dmesg.boot
-    [ ! -e "/var/run/dmesg.boot" ] && return 0
+    # try to load the vmm module
+    # we do this here to make sure the sysctls exist, and before disable_host_checks
+    # as we want this loaded anyway. FreeBSD version check removed as the
+    # module won't exist on systems too old for bhyve
+    util::load_module "vmm"
 
-    # get features2 line which should include popcnt
-    _mesg=$(grep -E '^[ ]+Features2' /var/run/dmesg.boot | tail -n 1)
+    # don't check if user wants to bypass host checks
+    util::checkyesno "$vm_disable_host_checks" && return 0
 
-    # only check if we found it
-    if [ -n "${_mesg}" ]; then
-
-        # look for pop cnt
-        _result=$(echo "${_mesg}" |grep "POPCNT")
-        [ -z "${_result}" ] && util::err "it doesn't look like your cpu supports bhyve (missing POPCNT)"
-    fi
-
-    # check ept for intel
-    _mesg1=$(grep -E '^[ ]+VT-x' /var/run/dmesg.boot | tail -n 1)
-    _mesg2=$(grep -E '^[ ]+Secondary Processor Controls' /var/run/dmesg.boot | tail -n 1)
-    _mesg="${_mesg1}${_mesg2}"
-
-    if [ -n "${_mesg}" ]; then
-
-        # look for ept
-        _result=$(echo "${_mesg}" |grep "EPT")
-        [ -z "${_result}" ] && util::err "it doesn't look like your cpu supports bhyve (missing EPT)"
-
-        # look for unrestricted guest
-        _result=$(echo "${_mesg}" |grep ",UG")
-        [ -z "${_result}" ] && VM_NO_UG="1"
-    fi
+    # check sysctls
+    [ "`sysctl -n hw.vmm.vmx.initialized 2>/dev/null`" != "1" ] && util::err "kernel vmm not initialised (no VT-x / AMD SVM cpu support?)"
+    [ "`sysctl -n hw.vmm.vmx.cap.unrestricted_guest 2>/dev/null`" != "1" ] && VM_NO_UG="1"
 }
 
 # check for passthru support
@@ -107,6 +89,11 @@ util::check_bhyve_support(){
 util::check_bhyve_iommu(){
     local _vtd
     local _amdvi
+
+    # don't check if user wants to bypass host checks
+    # think this check is fairly solid but there's probably someone somewhere
+    # with iommu support that our tests fail for.
+    util::checkyesno "$vm_disable_host_checks" && return 0
 
     _vtd=$(acpidump -t |grep DMAR)
     _amdvi=$(sysctl hw |grep 'vmm.amdvi.enable: 1')
@@ -135,7 +122,7 @@ util::restart_service(){
 # show version
 #
 util::version(){
-    echo "vm-bhyve: Bhyve virtual machine management v${VERSION} (build ${VERSION_INT})"
+    echo "vm-bhyve: Bhyve virtual machine management v${VERSION} (rev. ${VERSION_INT})"
 }
 
 # show version & usage information
@@ -164,10 +151,9 @@ Usage: vm ...
     datastore add <name> <path>
     list
     info [name] [...]
-    define <template.conf>
     create [-d datastore] [-t template] [-s size] <name>
-    [-fi] install <name> <iso>
-    [-fi] start <name> [...]
+    install [-fi] <name> <iso>
+    start [-fi] <name> [...]
     stop <name> [...]
     console <name> [com1|com2]
     configure <name>
@@ -175,9 +161,9 @@ Usage: vm ...
     add [-d device] [-t type] [-s size|switch] <name>
     startall
     stopall
-    [-f] reset <name>
-    [-f] poweroff <name>
-    [-f] destroy <name>
+    reset  [-f] <name>
+    poweroff [-f] <name>
+    destroy [-f] <name>
     passthru
     clone <name[@snapshot]> <new-name>
     snapshot [-f] <name[@snapshot]>
@@ -244,7 +230,7 @@ util::log_rotate(){
     esac
 
     if [ -e "${_file}" ]; then
-        _size=$(stat "${_file}" | cut -d' ' -f8)
+        _size=$(stat -f %z "${_file}")
 
         if [ -n "${_size}" -a "${_size}" -ge 1048576 ]; then
             unlink "${_file}.0.gz" >/dev/null 2>&1
@@ -271,16 +257,19 @@ util::log(){
     case "${_type}" in
         guest)
             _guest="$2"
-            _message="$3"
             _file="${VM_DS_PATH}/${_guest}/${_lf}"
+            shift 2
             ;;
         system)
-            _message="$2"
             _file="${vm_dir}/${_lf}"
+            shift 1
             ;;
     esac
 
-    echo "$(date +'%b %d %T'): ${_message}" >> "${_file}"
+    while [ -n "$1" ]; do
+      echo "$(date +'%b %d %T'): $1" >> "${_file}"
+      shift
+    done
 }
 
 # write content to a file, and log what we
@@ -346,8 +335,8 @@ util::checkyesno(){
     esac
 }
 
-# check a name contains no risky characters
-# currently limited to "0-9a-z.-", but without ".-" on the end or beginning
+# 'vm check name'
+# check name of virtual machine
 #
 # @param _name name to check
 # @param _maxlen=30 maximum name length (NOTE should be 2 less than desired)
@@ -358,5 +347,30 @@ util::check_name(){
     local _maxlen="$2"
 
     : ${_maxlen:=30}
-    echo "${_name}" | egrep -iqs "^[a-z0-9][.a-z0-9-]{0,${_maxlen}}[a-z0-9]\$"
+    echo "${_name}" | egrep -iqs "^[a-z0-9][.a-z0-9_-]{0,${_maxlen}}[a-z0-9]\$"
+}
+
+# check if the specified string is a valid core configuration
+# setting that the user can change
+#
+# @param string the setting name to look for
+#
+util::valid_config_setting(){
+    echo "${VM_CONFIG_USER}" | grep -iqs "${1};"
+}
+
+# __getpid
+# get a process id
+#
+# @param string _var variable to put pid into
+# @param string _proc process to look for
+#
+util::getpid(){
+    local _var="$1"
+    local _proc="$2"
+    local _ret
+
+    _ret=$(pgrep -f "${_proc}")
+    [ $? -eq 0 ] || return 1
+    setvar "${_var}" "${_ret}"
 }

--- a/lib/vm-util
+++ b/lib/vm-util
@@ -27,6 +27,7 @@
 # make sure we have the right environment
 #
 util::setup(){
+    util::load_module "vmm"
     util::load_module "nmdm"
     util::load_module "if_bridge"
     util::load_module "if_tap"
@@ -54,30 +55,47 @@ util::load_module(){
 }
 
 # check if system have bhyve support
-# look for sysctls set by the vmm module. I can't get confirmation that this
-# is a valid way to check vmm is working, even though it seems reasonable.
-# the vm_disable_host_checks="yes" rc settings allows bypassing all this
-# if your system should be supported but these checks break.
+# we look for POPCNT feature which is required
+# and should be listed on both Intel & AMD systems
 # 
 # @modifies VM_NO_UG
 #
 util::check_bhyve_support(){
+    local _mesg _mesg1 _mesg2 _result
 
-    # almost all our functionality requires access to things only root can do
+    # basic checks
     [ `id -u` -ne 0 ] && util::err "virtual machines can only be managed by root"
+    [ ${VERSION_BSD} -lt 1000000 ] && util::err "please upgrade to FreeBSD 10 or newer for bhyve support"
 
-    # try to load the vmm module
-    # we do this here to make sure the sysctls exist, and before disable_host_checks
-    # as we want this loaded anyway. FreeBSD version check removed as the
-    # module won't exist on systems too old for bhyve
-    util::load_module "vmm"
+    # can't check any further if we don't have a dmesg.boot
+    [ ! -e "/var/run/dmesg.boot" ] && return 0
 
-    # don't check if user wants to bypass host checks
-    util::checkyesno "$vm_disable_host_checks" && return 0
+    # get features2 line which should include popcnt
+    _mesg=$(grep -E '^[ ]+Features2' /var/run/dmesg.boot | tail -n 1)
 
-    # check sysctls
-    [ "`sysctl -n hw.vmm.vmx.initialized 2>/dev/null`" != "1" ] && util::err "kernel vmm not initialised (no VT-x / AMD SVM cpu support?)"
-    [ "`sysctl -n hw.vmm.vmx.cap.unrestricted_guest 2>/dev/null`" != "1" ] && VM_NO_UG="1"
+    # only check if we found it
+    if [ -n "${_mesg}" ]; then
+
+        # look for pop cnt
+        _result=$(echo "${_mesg}" |grep "POPCNT")
+        [ -z "${_result}" ] && util::err "it doesn't look like your cpu supports bhyve (missing POPCNT)"
+    fi
+
+    # check ept for intel
+    _mesg1=$(grep -E '^[ ]+VT-x' /var/run/dmesg.boot | tail -n 1)
+    _mesg2=$(grep -E '^[ ]+Secondary Processor Controls' /var/run/dmesg.boot | tail -n 1)
+    _mesg="${_mesg1}${_mesg2}"
+
+    if [ -n "${_mesg}" ]; then
+
+        # look for ept
+        _result=$(echo "${_mesg}" |grep "EPT")
+        [ -z "${_result}" ] && util::err "it doesn't look like your cpu supports bhyve (missing EPT)"
+
+        # look for unrestricted guest
+        _result=$(echo "${_mesg}" |grep ",UG")
+        [ -z "${_result}" ] && VM_NO_UG="1"
+    fi
 }
 
 # check for passthru support
@@ -89,11 +107,6 @@ util::check_bhyve_support(){
 util::check_bhyve_iommu(){
     local _vtd
     local _amdvi
-
-    # don't check if user wants to bypass host checks
-    # think this check is fairly solid but there's probably someone somewhere
-    # with iommu support that our tests fail for.
-    util::checkyesno "$vm_disable_host_checks" && return 0
 
     _vtd=$(acpidump -t |grep DMAR)
     _amdvi=$(sysctl hw |grep 'vmm.amdvi.enable: 1')
@@ -122,7 +135,7 @@ util::restart_service(){
 # show version
 #
 util::version(){
-    echo "vm-bhyve: Bhyve virtual machine management v${VERSION} (rev. ${VERSION_INT})"
+    echo "vm-bhyve: Bhyve virtual machine management v${VERSION} (build ${VERSION_INT})"
 }
 
 # show version & usage information
@@ -151,9 +164,10 @@ Usage: vm ...
     datastore add <name> <path>
     list
     info [name] [...]
+    define <template.conf>
     create [-d datastore] [-t template] [-s size] <name>
-    install [-fi] <name> <iso>
-    start [-fi] <name> [...]
+    [-fi] install <name> <iso>
+    [-fi] start <name> [...]
     stop <name> [...]
     console <name> [com1|com2]
     configure <name>
@@ -161,9 +175,9 @@ Usage: vm ...
     add [-d device] [-t type] [-s size|switch] <name>
     startall
     stopall
-    reset  [-f] <name>
-    poweroff [-f] <name>
-    destroy [-f] <name>
+    [-f] reset <name>
+    [-f] poweroff <name>
+    [-f] destroy <name>
     passthru
     clone <name[@snapshot]> <new-name>
     snapshot [-f] <name[@snapshot]>
@@ -230,7 +244,7 @@ util::log_rotate(){
     esac
 
     if [ -e "${_file}" ]; then
-        _size=$(stat -f %z "${_file}")
+        _size=$(stat "${_file}" | cut -d' ' -f8)
 
         if [ -n "${_size}" -a "${_size}" -ge 1048576 ]; then
             unlink "${_file}.0.gz" >/dev/null 2>&1
@@ -257,19 +271,16 @@ util::log(){
     case "${_type}" in
         guest)
             _guest="$2"
+            _message="$3"
             _file="${VM_DS_PATH}/${_guest}/${_lf}"
-            shift 2
             ;;
         system)
+            _message="$2"
             _file="${vm_dir}/${_lf}"
-            shift 1
             ;;
     esac
 
-    while [ -n "$1" ]; do
-      echo "$(date +'%b %d %T'): $1" >> "${_file}"
-      shift
-    done
+    echo "$(date +'%b %d %T'): ${_message}" >> "${_file}"
 }
 
 # write content to a file, and log what we
@@ -335,8 +346,8 @@ util::checkyesno(){
     esac
 }
 
-# 'vm check name'
-# check name of virtual machine
+# check a name contains no risky characters
+# currently limited to "0-9a-z.-", but without ".-" on the end or beginning
 #
 # @param _name name to check
 # @param _maxlen=30 maximum name length (NOTE should be 2 less than desired)
@@ -347,30 +358,5 @@ util::check_name(){
     local _maxlen="$2"
 
     : ${_maxlen:=30}
-    echo "${_name}" | egrep -iqs "^[a-z0-9][.a-z0-9_-]{0,${_maxlen}}[a-z0-9]\$"
-}
-
-# check if the specified string is a valid core configuration
-# setting that the user can change
-#
-# @param string the setting name to look for
-#
-util::valid_config_setting(){
-    echo "${VM_CONFIG_USER}" | grep -iqs "${1};"
-}
-
-# __getpid
-# get a process id
-#
-# @param string _var variable to put pid into
-# @param string _proc process to look for
-#
-util::getpid(){
-    local _var="$1"
-    local _proc="$2"
-    local _ret
-
-    _ret=$(pgrep -f "${_proc}")
-    [ $? -eq 0 ] || return 1
-    setvar "${_var}" "${_ret}"
+    echo "${_name}" | egrep -iqs "^[a-z0-9][.a-z0-9-]{0,${_maxlen}}[a-z0-9]\$"
 }

--- a/lib/vm-util
+++ b/lib/vm-util
@@ -151,6 +151,7 @@ Usage: vm ...
     datastore add <name> <path>
     list
     info [name] [...]
+    define <name.conf>
     create [-d datastore] [-t template] [-s size] <name>
     install [-fi] <name> <iso>
     start [-fi] <name> [...]


### PR DESCRIPTION
Hello, I'm a part of an organization which uses bhyve for virtualization. 
At first we tried the familiar libvirtd way. But there are tons of bugs which need to be resolved in order to be used properly. So I stumbled across this solution which is pretty neat. Way better then other implementations. So I started to migrate virtual machines from libvirtd to vm-bhyve. 
However I really liked the libvirtd "virsh define" functionality which basically just defines a new virtual machine from a template. vm-bhyve does have an adequate mechanism like
vm create
vm install 

But using vm define instead will grant users to be able to create "smarter" pipelines for creating virtual machines.
At the moment I have available zfs snapshots from which I clone new windows10, windows2012r2,windows2016 ubuntu machines. Editing a simple template.conf and passing it to vm define and then running vm start. Works like a charm.

Please take a look and tell me what you think. 
It would also be nice to have vm undefine - which will simply delete the virtual machine folder.
form the vm-bhyve workspace directory.

Regards
Your everyday random wizard