### PR TITLE
Check qemu img exit status

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,9 @@ See the man page for a full description of all available commands.
 
 You can use cloud images to create virtual machines. The `vm img` command will download the image to datastore and 
 uncompress it if needed (.xz, .tar.gz, and .gz files are supported). The image should be in RAW or QCOW2 format.
+To use this feature you'll need install qemu-utils package:
+
+    # pkg install qemu-utils
 
 To launch FreeBSD using official cloud image:
 

--- a/lib/vm-core
+++ b/lib/vm-core
@@ -206,6 +206,9 @@ core::write_img(){
     # just run start with an iso
     datastore::img_find "_imgpath" "${_img}" || util::err "unable to locate img file - '${_img}'"
     qemu-img dd -O raw if="${_imgpath}" of="${_disk_dev}" bs=1M
+    if [ $? -ne 0 ]; then
+        util::err "failed to write img file with qemu-img"
+    fi
 }
 
 # 'vm add'


### PR DESCRIPTION
qemu-img may fail writing img when for example destination file is too small. Added a check for exit status from qemu-img.
While on that I also added a note to README about install qemu-utils to be able to use cloud images.