### PR TITLE
Add support for cloud-init

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,26 @@ To list downloaded images:
     default             Fedora-AtomicHost-28-1.1.x86_64.raw
     default             FreeBSD-11.2-RELEASE-amd64.raw
     default             xenial-server-cloudimg-amd64-uefi1.img
+
+## Using cloud init
+
+vm-bhyve has basic support for providing cloud-init configuration to the guest. You can enable it with `-C` option
+to `vm create` command. You can also pass public SSH key to be injected into the guest with option `-k <file>`. 
+
+Example:
+
+    # vm create -t linux -i xenial-server-cloudimg-amd64-uefi1.img -C -k ~/.ssh/id_rsa.pub cloud-init-ubuntu
+    # vm start cloud-init-ubuntu
+    Starting cloud-init-ubuntu
+    * found guest in /zroot/vm/cloud-init-ubuntu
+    * booting...
+    # ssh ubuntu@192.168.0.91
+    The authenticity of host '192.168.0.91 (192.168.0.91)' can't be established.
+    ECDSA key fingerprint is SHA256:6s9uReyhsIXRv0dVRcBCKMHtY0kDYRV7zbM7ot6u604.
+    No matching host key fingerprint found in DNS.
+    Are you sure you want to continue connecting (yes/no)? yes
+    Warning: Permanently added '192.168.0.91' (ECDSA) to the list of known hosts.
+    Welcome to Ubuntu 16.04.5 LTS (GNU/Linux 4.4.0-141-generic x86_64)
     
 ## Adding custom disks
 

--- a/lib/vm-core
+++ b/lib/vm-core
@@ -1,3 +1,4 @@
+#!/bin/sh
 #-------------------------------------------------------------------------+
 # Copyright (C) 2016 Matt Churchyard (churchers@gmail.com)
 # All rights reserved
@@ -97,9 +98,9 @@ core::list(){
 core::create(){
     local _name _opt _size _vmdir _disk _disk_dev _num=0
     local _zfs_opts _disk_size _template="default" _ds="default" _ds_path _img _cpu _memory _uuid
-    local _cloud_init_dir _ssh_public_key _ssh_key_file
+    local _enable_cloud_init _cloud_init_dir _ssh_public_key _ssh_key_file
 
-    while getopts d:t:s:i:c:m:k: _opt ; do
+    while getopts d:t:s:i:c:m:Ck: _opt ; do
         case $_opt in
             t) _template=${OPTARG} ;;
             s) _size=${OPTARG} ;;
@@ -108,6 +109,7 @@ core::create(){
             m) _memory=${OPTARG} ;;
             i) _img=${OPTARG} ;;
             k) _ssh_key_file=${OPTARG} ;;
+            C) _enable_cloud_init='true' ;;
 
             *) util::usage ;;
         esac
@@ -136,8 +138,16 @@ core::create(){
     # make sure template has a disk before we start creating anything
     [ -z "${_disk}" ] && util::err "template is missing disk0_name specification"
 
+    if [ -n "${_enable_cloud_init}" ]; then
+        if ! which genisoimage > /dev/null; then
+            util::err "Error: genisoimage is required to work with cloud init! Run 'pkg install cdrkit-genisoimage'."
+        fi
+    fi
+
     # get ssh public key for cloud-init from file
     if [ -n "${_ssh_key_file}" ]; then
+
+      [ -z "${_enable_cloud_init}" ] && util::err "cloud-init is required for injecting public key. Use -C to enable it."
       [ ! -r "${_ssh_key_file}" ] && util::err "can't read file with public key (${_ssh_key_file})"
       _ssh_public_key="$(cat "${_ssh_key_file}")"
     fi
@@ -195,31 +205,33 @@ core::create(){
         config::get "_disk_size" "disk${_num}_size" "20G"
     done
 
-    # create disk with metadata for cloud-init
-    _cloud_init_dir="${VM_DS_PATH}/${_name}/.cloud-init"
-    mkdir -p "${_cloud_init_dir}"
+    if [ -n "${_enable_cloud_init}" ]; then
+        # create disk with metadata for cloud-init
+        _cloud_init_dir="${VM_DS_PATH}/${_name}/.cloud-init"
+        mkdir -p "${_cloud_init_dir}"
 
-    cat << EOF > "${_cloud_init_dir}/meta-data"
+        cat << EOF > "${_cloud_init_dir}/meta-data"
 instance-id: ${_uuid}
 local-hostname: ${_name}
 EOF
 
-    if [ -n "${_ssh_public_key}" ]; then
-
-      cat << EOF > "${_cloud_init_dir}/user-data"
+        cat << EOF > "${_cloud_init_dir}/user-data"
 #cloud-config
-ssh_authorized_keys:
-  - ${_ssh_public_key}
 resize_rootfs: True
 manage_etc_hosts: localhost
 EOF
+        if [ -n "${_ssh_public_key}" ]; then
+            cat << EOF >> "${_cloud_init_dir}/user-data"
+ssh_authorized_keys:
+  - ${_ssh_public_key}
+EOF
+        fi
 
+        genisoimage -output "${VM_DS_PATH}/${_name}/seed.iso" -volid cidata -joliet -rock "${_cloud_init_dir}/meta-data" "${_cloud_init_dir}/user-data" > /dev/null 2>&1 || util::err "Can't write seed.iso for cloud-init"
+        config::set "${_name}" "disk${_num}_type" "ahci-cd"
+        config::set "${_name}" "disk${_num}_name" "seed.iso"
+        config::set "${_name}" "disk${_num}_dev" "file"
     fi
-
-    genisoimage -output "${VM_DS_PATH}/${_name}/seed.iso" -volid cidata -joliet -rock "${_cloud_init_dir}/meta-data" "${_cloud_init_dir}/user-data" > /dev/null 2>&1 || util:err "Can't write seed.iso for cloud-init"
-    config::set "${_name}" "disk${_num}_type" "ahci-cd"
-    config::set "${_name}" "disk${_num}_name" "seed.iso"
-    config::set "${_name}" "disk${_num}_dev" "file"
 
     exit 0
 }

--- a/lib/vm-core
+++ b/lib/vm-core
@@ -1,4 +1,3 @@
-#!/bin/sh
 #-------------------------------------------------------------------------+
 # Copyright (C) 2016 Matt Churchyard (churchers@gmail.com)
 # All rights reserved
@@ -97,9 +96,10 @@ core::list(){
 #
 core::create(){
     local _name _opt _size _vmdir _disk _disk_dev _num=0
-    local _zfs_opts _disk_size _template="default" _ds="default" _ds_path _img _cpu _memory
+    local _zfs_opts _disk_size _template="default" _ds="default" _ds_path _img _cpu _memory _uuid
+    local _cloud_init_dir _ssh_public_key _ssh_key_file
 
-    while getopts d:t:s:i:c:m: _opt ; do
+    while getopts d:t:s:i:c:m:k: _opt ; do
         case $_opt in
             t) _template=${OPTARG} ;;
             s) _size=${OPTARG} ;;
@@ -107,6 +107,8 @@ core::create(){
             c) _cpu=${OPTARG} ;;
             m) _memory=${OPTARG} ;;
             i) _img=${OPTARG} ;;
+            k) _ssh_key_file=${OPTARG} ;;
+
             *) util::usage ;;
         esac
     done
@@ -134,6 +136,12 @@ core::create(){
     # make sure template has a disk before we start creating anything
     [ -z "${_disk}" ] && util::err "template is missing disk0_name specification"
 
+    # get ssh public key for cloud-init from file
+    if [ -n "${_ssh_key_file}" ]; then
+      [ ! -r "${_ssh_key_file}" ] && util::err "can't read file with public key (${_ssh_key_file})"
+      _ssh_public_key="$(cat "${_ssh_key_file}")"
+    fi
+
     # if we're on zfs, make a new filesystem
     zfs::make_dataset "${VM_DS_ZFS_DATASET}/${_name}" "${_zfs_opts}"
 
@@ -144,7 +152,8 @@ core::create(){
     [ $? -eq 0 ] || util::err "unable to copy template to virtual machine directory"
 
     # generate a uuid
-    config::set "${_name}" "uuid" $(uuidgen)
+    _uuid=$(uuidgen)
+    config::set "${_name}" "uuid" ${_uuid}
 
     # get any zvol options
     config::get "_zfs_opts" "zfs_zvol_opts"
@@ -185,6 +194,32 @@ core::create(){
         config::get "_disk_dev" "disk${_num}_dev"
         config::get "_disk_size" "disk${_num}_size" "20G"
     done
+
+    # create disk with metadata for cloud-init
+    _cloud_init_dir="${VM_DS_PATH}/${_name}/.cloud-init"
+    mkdir -p "${_cloud_init_dir}"
+
+    cat << EOF > "${_cloud_init_dir}/meta-data"
+instance-id: ${_uuid}
+local-hostname: ${_name}
+EOF
+
+    if [ -n "${_ssh_public_key}" ]; then
+
+      cat << EOF > "${_cloud_init_dir}/user-data"
+#cloud-config
+ssh_authorized_keys:
+  - ${_ssh_public_key}
+resize_rootfs: True
+manage_etc_hosts: localhost
+EOF
+
+    fi
+
+    genisoimage -output "${VM_DS_PATH}/${_name}/seed.iso" -volid cidata -joliet -rock "${_cloud_init_dir}/meta-data" "${_cloud_init_dir}/user-data" > /dev/null 2>&1 || util:err "Can't write seed.iso for cloud-init"
+    config::set "${_name}" "disk${_num}_type" "ahci-cd"
+    config::set "${_name}" "disk${_num}_name" "seed.iso"
+    config::set "${_name}" "disk${_num}_dev" "file"
 
     exit 0
 }


### PR DESCRIPTION
This PR add support for generating seed.iso to feed cloud-init with configuration. I decided to keep it super simple and skipped implementing datastore for ssh keys - user can pass file with public key directly to `vm create` command.
I added two additional parameters for `vm create`:
 - -C - for enabling cloud-init and generating seed.iso file
 - -k - for specifying path to public key

I couldn't find a way to specify volume ID with `tar(1)` as suggested by @brd so it requires `genisoimage(1)` from `cdrkit-genisomage` package.

For now user-data template is hardcoded in vm-core. I have an idea how to make that better with templates but it would require additional dependency and I'll try to cover it with another PR.

Currently the effects of enabling cloud-init are:
 - hostname is set to virtual machine name from vm-bhyve (and entry in /etc/hosts is added)
 - partition is automatically resized to fill the whole backing device
 - public key is injected

Here's how it works:
```
monster-1% sudo ./vm create -t linux -i xenial-server-cloudimg-amd64-uefi1.img -C -k ~/.ssh/id_rsa.pub cloud-init-ubuntu
monster-1% sudo ./vm start cloud-init-ubuntu
Starting cloud-init-ubuntu
  * found guest in /zroot/vm/cloud-init-ubuntu
  * booting...
[Get IP from DHCP server]
monster-1% ssh ubuntu@192.168.0.91
The authenticity of host '192.168.0.91 (192.168.0.91)' can't be established.
ECDSA key fingerprint is SHA256:6s9uReyhsIXRv0dVRcBCKMHtY0kDYRV7zbM7ot6u604.
No matching host key fingerprint found in DNS.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added '192.168.0.91' (ECDSA) to the list of known hosts.
Welcome to Ubuntu 16.04.5 LTS (GNU/Linux 4.4.0-141-generic x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/advantage

  Get cloud support with Ubuntu Advantage Cloud Guest:
    http://www.ubuntu.com/business/services/cloud

0 packages can be updated.
0 updates are security updates.



The programs included with the Ubuntu system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Ubuntu comes with ABSOLUTELY NO WARRANTY, to the extent permitted by
applicable law.

To run a command as administrator (user "root"), use "sudo <command>".
See "man sudo_root" for details.

ubuntu@cloud-init-ubuntu:~$
```

@churchers waiting for your feedback.

Ref. https://github.com/churchers/vm-bhyve/issues/289