### PR TITLE
No more disks limitation with latest UEFI firmware

### DIFF
--- a/lib/vm-run
+++ b/lib/vm-run
@@ -502,11 +502,6 @@ vm::bhyve_device_disks(){
             if [ -n "${_uefi}" ]; then
                 _slot=$((_slot + 1))
 
-                # stop at slot 6 on uefi
-                if [ ${_slot} -ge 7 ]; then
-                    util::log "guest" "${_name}" "ending disks at disk${_num} due to UEFI firmware limitations"
-                    break
-                fi
             else
                 _func=$((_func + 1))
             fi


### PR DESCRIPTION
It seems we don't need to limit the number of disks since UEFI firmware version 0.2.
Tested with this setup: 2 ahci-hd, 2 nvme and 1 virtio-blk disks at the same time and no UEFI boot problem:

vm log file extract:
```
ar 01 15:57:25: booting
Mar 01 15:57:25:  [bhyve options: -c 8 -m 16G -Hwl bootrom,/usr/local/share/uefi-firmware/BHYVE_UEFI.fd -U 89b8d1cf-3c48-11e9-8a98-0cc47ad8c988 -u]
Mar 01 15:57:25:  [bhyve devices: -s 0,hostbridge -s 31,lpc -s 4:0,virtio-blk,/usr/local/vm/vm1/USB.img -s 5:0,nvme,/usr/local/vm/vm1/disk1.img -s 6:0,nvme,/usr/local/vm/vm1/disk2.img -s 7:0,ahci-hd,/usr/local/vm/vm1/disk3.img -s 8:0,ahci-hd,/usr/local/vm/vm1/disk4.img -s 9:0,e1000,tap2,mac=58:9c:fc:03:20:a0]
Mar 01 15:57:25:  [bhyve console: -l com1,/dev/nmdm-vm1.1A]
Mar 01 15:57:25:  [bhyve iso device: -s 3:0,ahci-cd,/usr/local/vm/.config/null.iso]
```

And from the VM:
```
# kenv efi-version
2.40
# kenv smbios.system.product
BHYVE
# sysctl kern.disks
kern.disks: ada7 ada6 nda1 nda0 cd0 vtbd0
```