### PR TITLE
Allow for custom UEFI firmware

### DIFF
--- a/lib/vm-core
+++ b/lib/vm-core
@@ -574,7 +574,7 @@ core::__start(){
 
     # check loader
     # uefi="" deprecated in 1.3, must be set via loader in 1.4
-    [ -z "${_loader}" -a -n "${_uefi}" ] && echo "  ! uefi setting is deprecated. please set loader=\"uefi\" or loader=\"uefi-csm\""
+    [ -z "${_loader}" -a -n "${_uefi}" ] && echo "  ! uefi setting is deprecated. please set loader=\"uefi\", loader=\"uefi-csm\" or loader=\"uefi-custom\""
 
     # check loader
     if [ "${_loader}" = "grub" ]; then

--- a/lib/vm-run
+++ b/lib/vm-run
@@ -139,6 +139,9 @@ vm::run(){
             uefi-csm)
                 _bootrom="/usr/local/share/uefi-firmware/BHYVE_UEFI_CSM.fd"
                 ;;
+            uefi-custom)
+                _bootrom="${VM_DS_PATH}/.config/BHYVE_UEFI.fd"
+                ;;                
             *)
                 _bootrom="/usr/local/share/uefi-firmware/BHYVE_UEFI.fd"
                 ;;

--- a/vm.8
+++ b/vm.8
@@ -317,7 +317,8 @@ You will also need a copy of the UEFI firmware.
 This can either be installed using the
 .Pa sysutils/uefi-edk2-bhyve
 port, or you can manually download a copy (see URL below) to
-.Pa $vm_dir/.config/BHYVE_UEFI.fd .
+.Pa $vm_dir/.config/BHYVE_UEFI.fd and configure a guest to use it by setting
+.Sy loader="uefi-custom" .
 .Pp
 If you are running
 .Fx 10
@@ -1007,8 +1008,9 @@ The valid options are
 .Sy bhyveload ,
 .Sy grub ,
 .Sy uefi ,
+.Sy uefi-csm ,
 or
-.Sy uefi-csm .
+.Sy uefi-custom .
 .It bhyveload_loader
 This option allows a custom path to be used for the loader inside the guest.
 Passed to


### PR DESCRIPTION
Prior to 1.3, vm-bhyve would check for:

$vm_dir/.config/BHYVE_UEFI.fd

Which is no longer probed for.  This causes guests not to start after upgrading to 1.3 as we use custom UEFI firmware and don't load the firmware from ports/packages.

Users should be able to continue to use firmware that isn't part of ports/packages, as long as it still resides in the documented location.

loader="uefi-custom" option has been added and documented to prevent any collisions with the new way the loader in invoked.