### PR TITLE
handle unified tuntap(4) after r347241

### DIFF
--- a/lib/vm-util
+++ b/lib/vm-util
@@ -29,7 +29,13 @@
 util::setup(){
     util::load_module "nmdm"
     util::load_module "if_bridge"
-    util::load_module "if_tap"
+    # tap(4) & tun(4) were unified in r347241, this is closest ABI bump
+    if [ `uname -U` -ge 1300029 ]; then
+        if_tap="if_tuntap"
+    else
+        if_tap="if_tap"
+    fi
+    util::load_module "${if_tap}"
 
     sysctl net.link.tap.up_on_open=1 >/dev/null 2>&1
 


### PR DESCRIPTION
In r347241 in FreeBSD HEAD, tun(4) and tap(4) have been merged.
We need to detect and handle which kernel module has to be loaded,
using the closest kernel ABI change in FreeBSD 13.0-CURRENT.

- https://svnweb.freebsd.org/base?view=revision&revision=r347241
- https://reviews.freebsd.org/D20044

If you can tag a release too, we can get the update into ports as well.