### PR TITLE
Allow manual configuration of boot disk

### DIFF
--- a/lib/vm-run
+++ b/lib/vm-run
@@ -54,7 +54,10 @@ vm::run(){
     config::load "${VM_DS_PATH}/${_name}/${_name}.conf"
     config::get "_memory" "memory"
     config::get "_loader" "loader"
-    config::get "_bootdisk" "disk0_name"
+    config::get "_bootdisk" "bootdisk"
+    if [ -z "${_bootdisk}" ]; then
+        config::get "_bootdisk" "disk0_name"
+    fi
     config::get "_bootdisk_dev" "disk0_dev" "file"
     config::get "_uefi" "uefi"
     config::get "_hostbridge" "hostbridge" "standard"


### PR DESCRIPTION
Allow the user to manually configure a boot disk by specifying
a bootdisk variable with a path as the value.  In particular,
this can be used to work around a limitation that prevents
booting from a virtio-scsi disk in Legacy/BIOS mode with bhyveload.
CTL disks, which are used for virtio-scsi, do not permit ordinary
"read" requests, so bhyveload cannot read from them.  Use this
bootdisk variable to point bhyveload directly to the zvol that
backs the CTL disk used for booting.