### PR TITLE
vm-rctl: match bhyve command before name update

### DIFF
--- a/lib/vm-rctl
+++ b/lib/vm-rctl
@@ -42,7 +42,7 @@ rctl::set(){
 
     # wait till bhyve starts and get pid
     sleep 1
-    _pid=$(pgrep -fx "bhyve: ${_name}")
+    _pid=$(pgrep -fx "bhyve[: ].* ${_name}")
     [ -z "${_pid}" ] && return 1
 
     # check for a priority


### PR DESCRIPTION
It takes about two seconds (on my 12.0-p5 system, at least) between bhyve launch (when the process is born) and when it updates its command name to from 'bhyve -c NCPU -m MEM ... ${_name}' to 'bhyve: ${_name}'. Change the pgrep pattern in vm-rctl to catch either state rather than fail and exit out.