### PR TITLE
Add (existing session) iSCSI support.

### DIFF
--- a/lib/vm-core
+++ b/lib/vm-core
@@ -187,6 +187,8 @@ core::create(){
                 ;;
             custom)
                 ;;
+            iscsi)
+                ;;
             *)
                 truncate -s "${_disk_size}" "${VM_DS_PATH}/${_name}/${_disk}"
                 [ $? -eq 0 ] || util::err "failed to create sparse file for disk image"

--- a/lib/vm-info
+++ b/lib/vm-info
@@ -325,6 +325,9 @@ info::guest_disks(){
                     _size=$(zfs get -Hp volsize "${_path#/dev/zvol/}" |cut -f3)
                     _used=$(zfs get -Hp refer "${_path#/dev/zvol/}" |cut -f3)
                     ;;
+                iscsi)
+                    _size=$(sysctl -b kern.geom.conftxt | awk "/ ${_path#/dev/} /{print \$4}")
+                    _used=${_size}
             esac
 
             if [ -n "${_size}" -a -n "${_used}" ]; then
@@ -463,4 +466,34 @@ info::__bytes_human(){
 
     export LC_ALL="C"
     printf "%.3f%s" "${_val}" "${_ext}"
+}
+
+info::__find_iscsi() {
+    local _var="$1"
+    # _target format: [iqn.*]unique_name[/N] where N is the lun# and defaults
+    # to 0. The address before the unique_name can be omitted so long as
+    # the unique_name is sufficient to select only one output of iscsictl -L.
+    local _target="$2"
+    local _lun _col _found
+
+    # If no lun is specified, assume /0
+    _lun=${_target##*/}
+    [ "${_lun}" = "${_target}" ] && _lun=0
+    _target=${_target%/*}
+
+    _found=$(iscsictl -L -w 10 | grep ${_target} | wc -l)
+    if [ "${_found}" -ne 1 ]; then
+        setvar "${_var}" ""
+        util::err "Unable to locate unique iSCSI device ${_target}"
+    fi
+
+    # _col to be the column of iscsictl -L we want
+    _col=$((_lun + 4))
+    _found=$(iscsictl -L | awk "/${_target}/{print \$${_col}}")
+    if echo "${_found}" | egrep -q '^da[0-9]+$'; then
+        setvar "${_var}" /dev/"${_found}"
+        return 0
+    fi
+
+    util::err "Unable to locate iSCSI device ${_target}/${_lun}"
 }

--- a/lib/vm-run
+++ b/lib/vm-run
@@ -830,6 +830,7 @@ vm::get_disk_path(){
         zvol)        ;&
         sparse-zvol) setvar "${_var}" "/dev/zvol/${VM_DS_ZFS_DATASET}/${_name}/${_disk}" ;;
         custom)      setvar "${_var}" "${_disk}" ;;
+        iscsi)       info::__find_iscsi "${_var}" "${_disk}" ;;
         *)           setvar "${_var}" "${VM_DS_PATH}/${_name}/${_disk}" ;;
     esac
 }

--- a/sample-templates/config.sample
+++ b/sample-templates/config.sample
@@ -171,9 +171,11 @@ disk0_type="virtio-blk"
 # For the zvol options, the zvol must be directly under the guest dataset.
 # There is also a 'custom' option, in which case the disk name should be the full path
 # to the file or device you want to use.
+# For 'iscsi', the disk name must be set to a unique target and lun combination
+# when matched against iscsictl -L output.
 #
 # Default: file
-# Valid Options: file,zvol,sparse-zvol,custom
+# Valid Options: file,zvol,sparse-zvol,custom,iscsi
 #
 disk0_dev=""
 
@@ -187,6 +189,7 @@ disk0_dev=""
 # file              'disk0.img' -> '$vm_dir/$name/disk0.img'
 # zvol|sparse-zvol  'disk0'     -> '/dev/zvol/pool/dataset/path/guest/disk0'
 # custom            '/dev/da10' -> '/dev/da10'
+# iscsi             'tgt[/lun]' -> '/dev/daNN' (lun defaults to 0 if omitted) 
 #
 disk0_name="disk0.img"
 

--- a/vm.8
+++ b/vm.8
@@ -1180,24 +1180,41 @@ command, which will create the disk image for you.
 Normally disk images or zvols are stored directly inside the guest.
 To use a disk image that is stored anywhere else, you can specify the full path
 in this option, and configure the device as
-.Sy custom
+.Sy custom .
+.Pp
+To use an established iscsi device, specify a target 'session[/lun]' 
+(default /0) which matches a unique session from the 
+.Pf ' Xr iscsictl 8
+-L' command output, and configure the device as
+.Sy iscsi .
 .It disk0_dev
 The type of device to use for the disk.
 If not specified, this will default to
 .Sy file ,
 and a sparse file, located in the guest directory, will be used as the disk
 image.
-Other options include
+Other options include:
 .Sy zvol
-&
-.Sy sparse-zvol ,
-which will use a ZVOL as the disk image, created directly under the guest
-dataset.
-Alternatively you can specify
+or 
+.Sy sparse-zvol
+(which will use a ZVOL as the disk image, created directly under the guest
+dataset),
+.Sy custom , 
+and 
+.Sy iscsi .
+.Pp
+When using
 .Sy custom ,
-in which case
+the 
 .Pa diskX_name
-should be the full path to the image file or device.
+parameter must be set to the full path to the image file or device.
+.Pp
+Already attached iscsi devices can have their device nodes dynamically
+detected and used by setting this option to
+.Sy iscsi
+and
+.Pa diskX_name
+as described above.
 .It disk0_opts
 Any additional options to use for this disk device.
 Multiple options can be specified, separated by a comma.


### PR DESCRIPTION
Adds support for using existing iSCSI sessions as the backing store. Auto-detects what `/dev/daN` device they've been assigned. Supports multiple LUNs per session. Also detects size (reports as size and used) for `vm info` output.

Tested with my own systems with iSCSI devices.