### PR TITLE
Add nvme description since 12.0R support nvme emulation.

### DIFF
--- a/sample-templates/config.sample
+++ b/sample-templates/config.sample
@@ -161,7 +161,7 @@ ahci_device_limit="8"
 # This specifies the emulation type for disk0. Please note that each disk requires
 # at least a type and name.
 #
-# Valid Options: virtio-blk,ahci-hd,ahci-cd
+# Valid Options: virtio-blk,ahci-hd,ahci-cd,nvme
 #
 disk0_type="virtio-blk"
 

--- a/vm.8
+++ b/vm.8
@@ -1154,8 +1154,9 @@ At least one virtual disk is required.
 Valid options for this are currently
 .Sy virtio-blk ,
 .Sy ahci-hd
-and
 .Sy ahci-cd .
+and
+.Sy nvme .
 Additional disks can be added by adding additional
 .Sy diskX_type
 and


### PR DESCRIPTION
Since 12.0R support nvme storage emulation, adding nvme support to vm-bhyve. 
(only document is updated, code is fine without modification)