### PR TITLE
Add real/idle-time priority options.

### DIFF
--- a/lib/vm-rctl
+++ b/lib/vm-rctl
@@ -30,10 +30,12 @@
 #
 rctl::set(){
     local _pcpu _rbps _wbps _riops _wiops
-    local _pid _pri
+    local _pid _pri _hpmode _lpmode
 
     # get limit settings
     config::get "_pri" "priority"
+    config::get "_hpmode" "high_priority" "no"
+    config::get "_lpmode" "low_priority" "no"
     config::get "_pcpu" "limit_pcpu"
     config::get "_rbps" "limit_rbps"
     config::get "_wbps" "limit_wbps"
@@ -45,8 +47,14 @@ rctl::set(){
     _pid=$(pgrep -fx "bhyve[: ].* ${_name}")
     [ -z "${_pid}" ] && return 1
 
-    # check for a priority
-    [ -n "${_pri}" ] && renice ${_pri} ${_pid} >/dev/null 2>&1
+    # check for a priority; highest level of (low_|high_)?priority wins
+    if [ "${_hpmode}" = "yes" ]; then
+        rtprio 31 -${_pid} >/dev/null 2>&1
+    elif [ -n "${_pri}" ]; then
+        renice ${_pri} ${_pid} >/dev/null 2>&1
+    elif [ "${_lpmode}" = "yes" ]; then
+        idprio 0 -${_pid} >/dev/null 2>&1
+    fi
 
     # return if there are no limits
     [ -z "${_pcpu}${_rbps}${_wbps}${_riops}${_wiops}" ] && return 1

--- a/sample-templates/config.sample
+++ b/sample-templates/config.sample
@@ -460,10 +460,30 @@ prestart="myscript.pl"
 
 # priority
 # set a priority (nice value) for a guest
-# valid range is -20 (highest) to 20 (only run when system idle), with
-# 0 being the default system priority
+# valid range is -20 (highest) to 20 (only run when system idle), with 0 being
+# the default system priority. Setting this value will override the
+# low_priority setting.
+# 
+# See also: low_priority and high_priority
 #
 priority="10"
+
+# high_priority
+# run with a real-time priority
+# Set this to yes (default is no) to use 'rtprio 31' to run in the (lowest
+# priority) real-time queue. This is an even higher priority than setting
+# priority="-20". Setting to "yes" overrides priority and low_priority.
+# settings.
+#
+high_priority="no"
+
+# low_priority
+# run in the idle scheduling class
+# Set this to yes (default is no) to use 'idprio 0' to run only in the
+# idle queue. This is below priority="20". Setting 'priority' or enabling
+# 'high_priority' will override the value of this option.
+#
+low_priority="no"
 
 # limit_pcpu
 # use rctl to limit guest to the specified cpu percentage


### PR DESCRIPTION
Adds new high_ and low_priority options (enable with "yes") which
use rtprio 31 and idprio 0 (lowest of the high, and highest of the
low) to move the executing bhyve into the real or idle-time
scheduling buckets. Options override preferring highest priority
specified.