### PR TITLE
Fix UART console on FreeBSD 12.1 and CURRENT.

### DIFF
--- a/lib/vm-run
+++ b/lib/vm-run
@@ -272,7 +272,7 @@ vm::run(){
               ${_devices} \
               ${_iso_dev} \
               ${_comstring} \
-              ${_name} >>"${_logpath}" 2>&1
+              ${_name} 2> "${_logpath}"
 
         # get bhyve exit code
         _exit=$?


### PR DESCRIPTION
The fix for issue #332 turns out to be simple.  Tested on 11.3 and 12.1.
