### PR TITLE
Add vm top command

### DIFF
--- a/lib/vm-cmd
+++ b/lib/vm-cmd
@@ -26,7 +26,7 @@
 
 CMD_VALID_LIST="init,switch,datastore,image,get,set,list,create,destroy,rename,install,start,stop,restart"
 CMD_VALID_LIST="${CMD_VALID_LIST},add,reset,poweroff,startall,stopall,console,iso,img,configure,passthru,_run"
-CMD_VALID_LIST="${CMD_VALID_LIST},info,clone,snapshot,rollback,send,recv,version,usage"
+CMD_VALID_LIST="${CMD_VALID_LIST},top,info,clone,snapshot,rollback,send,recv,version,usage"
 
 # cmd: vm ...
 #
@@ -67,6 +67,7 @@ cmd::parse(){
         image)     cmd::parse_image "$@" ;;
         get)       core::get "$@" ;;
         set)       core::set "$@" ;;
+        top)       core::top ;;
         list)      core::list ;;
         create)    core::create "$@" ;;
         destroy)   core::destroy "$@" ;;

--- a/lib/vm-core
+++ b/lib/vm-core
@@ -24,6 +24,36 @@
 # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+# 'vm top'
+# Wrap system top output
+# by adding vm name after process name
+#
+core::top(){
+
+    local _run
+
+    _run=$(pgrep -fl "bhyve:" | awk '{printf $1","$NF"|"}')
+    while sleep 1;
+    do
+        top -b | awk -v run="$_run" '
+        BEGIN{
+          split(run,runlist,"|");
+          for(i=1;i<length(runlist);i++){
+            split(runlist[i],idname,",");
+            idnamemap[idname[1]]=idname[2];
+          }
+        }
+        {
+          if($1 in idnamemap){
+            print $0 "("idnamemap[$1]")"
+          }
+          else{
+            print $0
+          }
+        }';
+    done
+}
+
 # 'vm list'
 # list virtual machines
 #

--- a/vm.8
+++ b/vm.8
@@ -82,6 +82,8 @@
 .Op Fl f
 .Ar name
 .Nm
+.Cm top
+.Nm
 .Cm list
 .Nm
 .Cm info
@@ -631,6 +633,9 @@ Unless specified, the guest image will be a sparse file 20GB in size.
 .It Cm destroy Ar name
 Removes the specified virtual machine from the system, deleting all associated
 disk images & configuration.
+.It Cm top
+.br
+Add VM Name to System top output for management purpose. Ctrl+C to quit.
 .It Cm list
 .br
 List all the virtual machines in the


### PR DESCRIPTION
system top command only show bhyve as below missing the vm name.
```
  PID USERNAME    THR PRI NICE   SIZE    RES STATE    C   TIME    WCPU COMMAND
 4761 root         23  20    0  8263M  7910M kqread  26 262:28  18.36% bhyve
 5693 root         15  20    0    16G  2835M kqread  33  64:41   3.52% bhyve
 4011 root         25  41    0  4142M  3932M kqread   7 381:22   2.25% bhyve
 5246 root         22  20    0  8241M  3081M kqread  10  27:46   0.98% bhyve
 4317 root         14  20    0  8240M  2039M kqread  33  23:44   0.59% bhyve
 3726 root         24  20    0  8246M   235M kqread   5   1:28   0.00% bhyve
```
vm top command will wrap system top output, adding 
vm name to bhyve instance.
```
  PID USERNAME    THR PRI NICE   SIZE    RES STATE    C   TIME    WCPU COMMAND
 4761 root         23  20    0  8263M  7910M kqread  26 262:28  18.36% bhyve(tb203)
 5693 root         15  20    0    16G  2835M kqread  33  64:41   3.52% bhyve(sw211)
 4011 root         25  41    0  4142M  3932M kqread   7 381:22   2.25% bhyve(synas)
 5246 root         22  20    0  8241M  3081M kqread  10  27:46   0.98% bhyve(v6net)
 4317 root         14  20    0  8240M  2039M kqread  33  23:44   0.59% bhyve(xl214)
 3726 root         24  20    0  8246M   235M kqread   5   1:28   0.00% bhyve(xl208)
```