### PR TITLE
add cpu usage using vm list command

### DIFF
--- a/lib/vm-run
+++ b/lib/vm-run
@@ -885,10 +885,12 @@ vm::running_check(){
     local _name="$2"
     local IFS=$'\n'
     local _entry
+    local _cpuusage
 
     for _entry in ${VM_RUN_BHYVE}; do
         if [ "${_entry##* }" = "${_name}" ]; then
-            setvar "${_var}" "Running (${_entry%% *})"
+            setvar _cpuusage `ps -o '%cpu=' -p ${_entry%% *}`
+            setvar "${_var}" `printf "Running %-8s%4s%%" "(${_entry%% *})" "${_cpuusage}"`
             return 0
         fi
     done


### PR DESCRIPTION
Be able to view the CPU usage quickly when using ```vm list``` command.
```
root@vmhost168:~ # vm list
NAME   DATASTORE  LOADER    CPU  MEMORY  VNC            AUTOSTART  STATE
tb203  default    uefi      4    8G      0.0.0.0:59203  No         Running (8148)  25.1%
uefi   default    uefi      8    8G      0.0.0.0:5900   No         Running (15905)  0.3%
v6net  default    uefi      2    8G      0.0.0.0:59021  No         Running (7225)   0.5%
xl207  default    uefi      4    8G      0.0.0.0:59207  No         Running (7707)  22.6%
synas  tank       uefi-csm  8    4G      -              No         Running (6029)   2.1%
xl208  tank       uefi      4    8G      0.0.0.0:59208  No         Running (6399)   0.0%
xl214  tank       uefi      4    8G      0.0.0.0:59214  No         Running (6749)   0.6%
```