### PR TITLE
disk0_size example should include suffix

### DIFF
--- a/sample-templates/config.sample
+++ b/sample-templates/config.sample
@@ -189,7 +189,7 @@ disk0_dev=""
 # file              'disk0.img' -> '$vm_dir/$name/disk0.img'
 # zvol|sparse-zvol  'disk0'     -> '/dev/zvol/pool/dataset/path/guest/disk0'
 # custom            '/dev/da10' -> '/dev/da10'
-# iscsi             'tgt[/lun]' -> '/dev/daNN' (lun defaults to 0 if omitted) 
+# iscsi             'tgt[/lun]' -> '/dev/daNN' (lun defaults to 0 if omitted)
 #
 disk0_name="disk0.img"
 
@@ -205,7 +205,9 @@ disk0_opts=""
 # disk0_size
 # When a new guest is created, vm will create a 20G disk image by
 # default. This option can be used to specify a different size
-# for this disk.
+# for this disk. Make sure to include a human readable suffix
+# compatible with 'zfs create' (G for gigabytes, T terabytes,
+# etc)
 #
 # The size of the first disk (disk0) can also be overridden
 # using the -s option to 'vm create'.
@@ -216,7 +218,7 @@ disk0_opts=""
 # a new guest, all 'diskX_size' options are stripped from
 # its configuration file.
 #
-disk0_size="50"
+disk0_size="50G"
 
 # network0_type
 # This specifies the emulation type to use for the first network interface.


### PR DESCRIPTION
## Description

Using the example for `disk0_size=50` in: https://github.com/churchers/vm-bhyve/blob/master/sample-templates/config.sample Made the correct and put a note in the `config.example`.

I was seeing the following error without adding the suffix for `disk0_size`:

Template:
```
~ # cat /zroot/vm/.templates/scale-monitoring.conf 
loader="grub"
cpu=4
memory=16G
network0_type="virtio-net"
network0_switch="public"
disk0_name="disk0"
disk0_dev="sparse-zvol"
disk0_type="virtio-blk"
disk0_size="1000"
```

Creation:
```
~ # vm create -i ~/imgs/bionic-server-cloudimg-amd64.raw -t scale-monitoring -C -n "ip=10.128.3.6/24;gateway=10.128.3.1;nameservers=8.8.8.8,8.8.4.4" -k ~/authorized_key_bootstrap monitoring
cannot create 'zroot/vm/monitoring/disk0': volume size must be a multiple of volume block size
/usr/local/sbin/vm: ERROR: failed to create new ZVOL zroot/vm/monitoring/disk0
```

## Fix

Instead it needs the suffix. In this case `G` for gigabytes:
```
~ # cat /zroot/vm/.templates/scale-monitoring.conf 
loader="grub"
cpu=4
memory=16G
network0_type="virtio-net"
network0_switch="public"
disk0_name="disk0"
disk0_dev="sparse-zvol"
disk0_type="virtio-blk"
disk0_size="1000G"
```

Result:
```
~ # vm info monitoring
------------------------
Virtual Machine: monitoring
------------------------
  state: stopped
  datastore: default
  loader: grub
  uuid: 1af6d0af-5341-11ea-b924-00259066a98c
  cpu: 4
  memory: 16G

  network-interface
    number: 0
    emulation: virtio-net
    virtual-switch: public
    fixed-mac-address: 58:9c:fc:0a:a8:f3
    fixed-device: -

  virtual-disk
    number: 0
    device-type: sparse-zvol
    emulation: virtio-blk
    options: -
    system-path: /dev/zvol/zroot/vm/monitoring/disk0
    bytes-size: 1073741824000 (1000.000G)
    bytes-used: 787562496 (751.078M)

  virtual-disk
    number: 1
    device-type: file
    emulation: ahci-cd
    options: -
    system-path: /zroot/vm/monitoring/seed.iso
    bytes-size: 376832 (368.000K)
    bytes-used: 13312 (13.000K)
```

## System Info

```
~ # uname -a
FreeBSD devil2 12.1-RELEASE FreeBSD 12.1-RELEASE r354233 GENERIC  amd64
~ # vm version
vm-bhyve: Bhyve virtual machine management v1.5-devel (rev. 105010)
```