### PR TITLE
add uefi-devel option

### DIFF
--- a/lib/vm-run
+++ b/lib/vm-run
@@ -122,6 +122,9 @@ vm::run(){
         fi
 
         case "${_loader}" in
+            uefi-devel)
+		_bootrom="/usr/local/share/uefi-firmware/BHYVE_UEFI_CODE-devel.fd"
+		;;
             uefi-csm)
                 _bootrom="/usr/local/share/uefi-firmware/BHYVE_UEFI_CSM.fd"
                 ;;


### PR DESCRIPTION
UEFI http boot is available in the port sysutils/uefi-edk2-bhyve-devel.
To used this option, I just modify there in the lib file vm-run.