### PR TITLE
When build bhyve device string, populate nic slot before disk's. 

### DIFF
--- a/lib/vm-run
+++ b/lib/vm-run
@@ -183,8 +183,8 @@ vm::run(){
     # build bhyve device string
     vm::bhyve_device_comports
     vm::bhyve_device_basic
-    vm::bhyve_device_disks
     vm::bhyve_device_networking
+    vm::bhyve_device_disks
     vm::bhyve_device_rand
     vm::bhyve_device_passthru
     vm::bhyve_device_fbuf


### PR DESCRIPTION
Currently NIC slot is populate after disks.
When user add or remove disks.(cause disk controller change)
NIC slot also change too.

For headless virtual machine. this behaver will make IP address setting in OS false.
for example, Windows will regonize additional NIC adapter, Linux also. (Populate device name usally by SLOT Number.)

This pull request change the populate sequence. NIC slot first.