### PR TITLE
Replace uname -U with uname -K when loading if_tuntap.ko

### DIFF
--- a/lib/vm-util
+++ b/lib/vm-util
@@ -31,7 +31,7 @@ util::setup(){
     util::load_module "if_bridge"
 
     # tap(4) & tun(4) were unified in r347241, this is closest ABI bump
-    if [ `uname -U` -ge 1300029 ]; then
+    if [ `uname -K` -ge 1300029 ]; then
         util::load_module "if_tuntap"
     else
         util::load_module "if_tap"


### PR DESCRIPTION
In an environment with an older FreeBSD kernel (e.g. `12.1-RELEASE`), when `chroot`-ing into a FreeBSD `13-CURRENT` environment and running `vm init` the following error shows up:

```
root@scylla2:/ # vm init
/usr/local/sbin/vm: ERROR: unable to load if_tuntap.ko!
```

This happens because the check performed in `vm-util` uses `uname -U` rather than `uname -K`, giving the userland version rather than the kernel version. For example:

```
root@scylla2:/ # uname -K
1201000
root@scylla2:/ # uname -U
1300077
```

Since `if_tuntap.ko` is a kernel module, this pull request simply changes the check to use `uname -K`, making it possible to use `vm-bhyve` in an environment where the userland and kernel are not the same revision, thus making it possible to use with `chroot` or jails.