### PR TITLE
Enable setting passthrough opts.

### DIFF
--- a/lib/vm-run
+++ b/lib/vm-run
@@ -754,10 +754,12 @@ vm::bhyve_device_passthru(){
     local _dev _orig_slot _func=0
     local _last_orig_slot
     local _num=0
+    local _popts
 
     while true; do
         config::get "_dev" "passthru${_num}"
         [ -z "${_dev}" ] && break
+        config::get "_popts" "passthru${_num}_opts"
 
         # see if there's an = sign
         # we allow A/B/C=D:E to force D:E as the guest SLOT:FUNC
@@ -779,6 +781,7 @@ vm::bhyve_device_passthru(){
             _func=$((_func + 1))
         fi
 
+        [ -n "${_popts}" ] && _devices="${_devices},${_popts}"
         _num=$((_num + 1))
     done
 


### PR DESCRIPTION
The upcoming patch, [D26209](https://reviews.freebsd.org/D26209), require passthrough device has an opts, which is `igd`.
Currently vm-bhyve is unable to add any extra opts to the passthru config.

This patch will enable `vm-bhyve` accept config such as 
```
passthru0="0/2/0=2:0"
passthru0_opts="igd"
```