### PR TITLE
Fix provision issue in case of zfs datasets

### DIFF
--- a/lib/vm-zfs
+++ b/lib/vm-zfs
@@ -447,7 +447,7 @@ zfs::image_provision(){
         xz)  xz -dc "${vm_dir}/images/${_file}" 2>/dev/null | zfs recv "${VM_DS_ZFS_DATASET}/${_name}" ;;
         z)   _decompress=$(sysrc -inqf "${vm_dir}/images/${_uuid}.manifest" decompress)
              [ -z "${_decompress}" ] && util::err "unable to locate decompression configuration"
-             ${_decompress} "${vm_dir}/images/${_file}" 2>/dev/null | zfs recv "${VM_DS_ZFS_DATASET}/${_name}" ;;
+             ${_decompress} <"${vm_dir}/images/${_file}" 2>/dev/null | zfs recv "${VM_DS_ZFS_DATASET}/${_name}" ;;
         *)   util::err "unsupported guest image type - '${_type}'" ;;
     esac
 


### PR DESCRIPTION
When the original image was made on zfs, the provisioning was
unsuccesfull, because of the .z filename suffix:

```
root@risa:~ # xz -d /vm/images/dade72b7-430f-11eb-b96a-244bfec86f45.zfs.z | zfs recv zroot/vm/t_ubuntu20.04LTS
xz: /vm/images/dade72b7-430f-11eb-b96a-244bfec86f45.zfs.z: Filename has an unknown suffix, skipping
cannot receive: failed to read from stream
root@risa:~ # cat /vm/images/dade72b7-430f-11eb-b96a-244bfec86f45.manifest

description="Template:Ubuntu_20.04LTS"
created="Sun Dec 20 22:08:14 UTC 2020"
name="t_ubuntu20.04LTS"
filename="dade72b7-430f-11eb-b96a-244bfec86f45.zfs.z"
decompress="xz -d"
root@risa:~ # xz -d </vm/images/dade72b7-430f-11eb-b96a-244bfec86f45.zfs.z | zfs recv zroot/vm/t_ubuntu20.04LTS
root@risa:~ # echo $?
0
```