### PR TITLE
img/iso: error if URL appears to contain incorrect format

### DIFF
--- a/lib/vm-core
+++ b/lib/vm-core
@@ -916,8 +916,9 @@ core::configure(){
 core::iso(){
     local _url _ds="default"
 
-    while getopts d:u _opt ; do
+    while getopts fd:u _opt ; do
         case $_opt in
+	    f) _force=1 ;;
             d) _ds=${OPTARG} ;;
             *) util::usage ;;
         esac
@@ -928,6 +929,14 @@ core::iso(){
 
     if [ -n "${_url}" ]; then
         datastore::get_iso "${_ds}" || util::err "unable to locate path for datastore '${_ds}'"
+        _filename=$(basename "${_url}")
+        if echo "${_filename}" | grep "\.raw" > /dev/null; then
+          if [ -z "${_force}" ]; then
+            util::err "${_filename} appears to be a raw image instead of an ISO. Use 'vm img' (or -f to force)"
+	  else
+            util::warn "${_filename} appears to be a raw image instead of an ISO . It is unlikely to boot properly."
+	  fi
+	fi
         fetch -o "${VM_DS_PATH}" "${_url}"
     else
         datastore::iso_list
@@ -967,8 +976,9 @@ core::img(){
         util::err "Error: qemu-img is required to work with cloud images! Run 'pkg install qemu-utils'."
     fi
 
-    while getopts d:u _opt ; do
+    while getopts fd:u _opt ; do
         case $_opt in
+	    f) _force=1 ;;
             d) _ds=${OPTARG} ;;
             *) util::usage ;;
         esac
@@ -980,6 +990,13 @@ core::img(){
     if [ -n "${_url}" ]; then
         datastore::get_img "${_ds}" || util::err "unable to locate path for datastore '${_ds}'"
         _filename=$(basename "${_url}")
+        if echo "${_filename}" | grep "\.iso" > /dev/null; then
+          if [ -z "${_force}" ]; then
+            util::err "${_filename} appears to be an ISO instead of a raw image. Use 'vm iso' (or -f to force)"
+	  else
+            util::warn "${_filename} appears to be an ISO instead of a raw image. It is unlikely to boot properly."
+	  fi
+	fi
         fetch -o "${VM_DS_PATH}" "${_url}"
         core::decompress "${VM_DS_PATH}/${_filename}"
     else

--- a/lib/vm-util
+++ b/lib/vm-util
@@ -181,8 +181,8 @@ Usage: vm ...
     clone <name[@snapshot]> <new-name>
     snapshot [-f] <name[@snapshot]>
     rollback [-r] <name@snapshot>
-    iso [url]
-    img [url]
+    iso [-f] [url]
+    img [-f] [url]
     image list
     image create [-d description] [-u] <name>
     image destroy <uuid>


### PR DESCRIPTION
This PR adjusts the `vm img` and `vm iso` commands to error if the URL is unlikely to contain the appropriately formatted image. It's crude, but should prevent most users from shooting themselves in the foot.

I spent about 4 hours trying to debug why my `archlinux` install wasn't working. It was because I passed the `.iso` path to `vm img`. This PR insures that fewer folks will run into the same issue. As an escape hatch, it adds a `-f` option to these commands.

Example output:

```
% sudo vm img http://mirrors.evowise.com/archlinux/iso/2020.12.01/archlinux-2020.12.01-x86_64.iso
/usr/local/sbin/vm: ERROR: archlinux-2020.12.01-x86_64.iso appears to be an ISO instead of a raw image. Use 'vm iso' (or -f to force)
```

```
sudo vm img -f http://mirrors.evowise.com/archlinux/iso/2020.12.01/archlinux-2020.12.01-x86_64.iso
/usr/local/sbin/vm: WARNING: archlinux-2020.12.01-x86_64.iso appears to be an ISO instead of a raw image. It is unlikely to boot properly.
/vm/.img/archlinux-2020.12.01-x86_64.iso        2% of  682 MB 6082 kBps 
```


