### PR TITLE
archlinux: Update boot paths for 2020 images

### DIFF
--- a/sample-templates/arch.conf
+++ b/sample-templates/arch.conf
@@ -5,5 +5,6 @@ network0_type="virtio-net"
 network0_switch="public"
 disk0_type="virtio-blk"
 disk0_name="disk0.img"
-grub_install0="linux /arch/boot/x86_64/vmlinuz archisobasedir=arch archisolabel=ARCH_201611 ro"
-grub_install1="initrd /arch/boot/x86_64/archiso.img"
+# The archisolabel does not need to be accurate.
+grub_install0="linux /arch/boot/x86_64/vmlinuz-linux archisobasedir=arch archisolabel=ARCH_202102 ro"
+grub_install1="initrd /arch/boot/x86_64/initramfs-linux.img"


### PR DESCRIPTION
The existing boot paths won't work with at least anything newer than 2020-11. 

Inspired by https://www.youtube.com/watch?v=npzxm_zegJY & tested locally.