### PR TITLE
Document new bhyveload_args configuration option.

### DIFF
--- a/sample-templates/config.sample
+++ b/sample-templates/config.sample
@@ -27,6 +27,12 @@ loader=""
 #
 bhyveload_loader=""
 
+# bhyveload_args
+# If using bhyveload, this option can be used to pass command line
+# arguments to the loader
+#
+bhyveload_args="-e machdep.hyperthreading_allowed=0"
+
 # loader_timeout
 # By default bhyveload & grub-bhyve will wait 3 seconds before booting the default
 # option. This setting allows you to either reduce the timeout to

--- a/vm.8
+++ b/vm.8
@@ -1072,6 +1072,11 @@ Passed to
 using the
 .Sy -l
 argument.
+.It bhyveload_args
+This option allows extra arguments to be given for the loader inside the guest.
+Appended verbatim to the
+.Sy bhyveload
+command line.
 .It loader_timeout
 By default the
 .Sy bhyveload


### PR DESCRIPTION
I updated my vm-bhyve  source, and the rebase conflicted on an almost identical `bhyveload_options` I'd implemented last summer and forgotten to push upstream.  Here's the documentation I wrote.
