### PR TITLE
Wait for storage device to appear when creating a VM

### DIFF
--- a/lib/vm-core
+++ b/lib/vm-core
@@ -313,9 +313,18 @@ core::write_img(){
     shift $?
     _disk_dev="${1}"
     _img="$2"
+    timeout=30
+    i=0
 
     # wait a few seconds for newly created zvol device to appear
-    sleep 2
+    while [ $i -lt $timeout ]; do
+        if [ ! -r "${_disk_dev}" ]; then
+            sleep 1
+            i=$(($i+1))
+	else
+            break
+        fi
+    done
 
     # just run start with an iso
     datastore::img_find "_imgpath" "${_img}" || util::err "unable to locate img file - '${_img}'"


### PR DESCRIPTION
Hardcoded `sleep 2` turned out to be not enough for some environments and it was too much for most of deployments. This change adds a simple `while` loop to wait up to 30 seconds for zvol to appear. After that time if zvol still is not accessible it allows qemu-img to handle this and fail. It should also work for other storage backends.

This supersedes https://github.com/churchers/vm-bhyve/pull/424.