### PR TITLE
The default of utctime=yes was lost; restore it.

### DIFF
--- a/lib/vm-run
+++ b/lib/vm-run
@@ -141,7 +141,7 @@ vm::run(){
     [ -n "${_uuid}" ] && _opts="${_opts} -U ${_uuid}"
 
     # set utc time in opts if requested
-    if config::yesno "utctime"; then
+    if config::yesno "utctime" yes; then
         if [ ${VERSION_BSD} -ge 1002000 ]; then
             _opts="${_opts} -u"
         else


### PR DESCRIPTION
I can't believe I let this annoy me for a year+ before looking into it.  I also am puzzled that nobody else noticed it.
