### PR TITLE
security: Removed unsafe relative path sourcing.

### DIFF
--- a/vm
+++ b/vm
@@ -25,9 +25,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 # get libs
-if [ -e "./lib/vm-core" ]; then
-    LIB="./lib"
-elif [ -e "/usr/local/lib/vm-bhyve" ]; then
+if [ -e "/usr/local/lib/vm-bhyve" ]; then
     LIB="/usr/local/lib/vm-bhyve"
 else
     echo "unable to locate vm-bhyve libraries"


### PR DESCRIPTION
The "vm" script is responsible for executing shell script
functions found in other vm-bhyve scripts. It does this by
sourcing other vm-bhyve shell scripts, which automatically
execute code that handles the user's input.

One of the first actions "vm" takes is to check if the relative
file "./lib/vm-core" exists. If this file exists, it sets
the parent directory for sourcing scripts to "./lib",
resulting in all shell scripts being sourced from a path
relative to the user's current working directory.

This is unsafe because sourcing from a relative file path
may result in execution of untrusted code.

For example, imagine the user cloned a git repository that
contains malicious code stored at "<git-dir>/lib/". If the
user were to "cd" to this imaginary cloned repository and
execute the "vm" script, they would inadvertently source and
execute code from that directory.

This commit removes this behavior. The "vm" script now
sources scripts exclusively from "/usr/local/lib/vm-bhyve/".