### PR TITLE
vnc: Generate a random password if none specified.

### DIFF
--- a/lib/vm-run
+++ b/lib/vm-run
@@ -611,7 +611,19 @@ vm::bhyve_device_fbuf(){
     config::get "_res" "graphics_res"
     config::get "_vga" "graphics_vga"
     config::get "_pass" "vnc_password"
+    config::get "_allow_no_pass" "insecure_allow_no_vnc_password"
     config::get "_wait" "graphics_wait" "auto"
+
+    if [ -z "${_pass}" ] && ! util::yesno "${_allow_no_pass}"; then
+        # Note: The VNC protocol limits passwords 8 characters. The following
+        # pipeline reads some random data, base64 encodes it, and grabs the
+        # first 8 characters. Base64 encoding is used instead of hex encoding
+        # to increase entropy ({a-f,0-9} vs. {a-z,A-Z,0-9,+,/}). We avoid
+        # predictable "=" padding characters by grabbing only the first 8 of
+        # the 10 characters.
+        _pass="$(head -c 10 /dev/random | b64encode -r - | head -c 8)"
+        util::log "guest" "${_name}" "generated random vnc password: '${_pass}'"
+    fi
 
     # check if graphics_wait is auto
     # auto will count as yes so we need to unset it if we're not in an install.

--- a/vm.8
+++ b/vm.8
@@ -1424,6 +1424,13 @@ If set to yes, a frame buffer is added to the guest.
 This provides a graphical console that is accessible using VNC.
 By default the console is 800x600, and will listen on
 .Sy 0.0.0.0:5900 .
+A random VNC password is generated and logged to the guest's log file if none
+is configured.  A password can be provided by specifying the
+.Sy vnc_password
+parameter in the guest's configuration file if desired.
+Automatic password generation can be disabled by specifying
+.Sy insecure_allow_no_vnc_password=yes
+in the guest's configuration file.
 If port 5900 is not available, the next available port will be used.
 The active address and port can be viewed in
 .Sy vm list


### PR DESCRIPTION
Currently, the VNC server is started without a password if
none was specified in the guest's configuration file (this
is normally done with the "vnc_password" parameter).

This commit changes this behavior to automatically generate
a random password if none is configured. This can be disabled
by specifying a configuration parameter.

There does not appear to be a way to get the password back
to the user via stdout. Since the password already appears
in the guest's log file, I felt that was a sensible place to
store it for now.

In addition to improving the default security of a guest,
this change also allows macOS' builtin VNC client to connect.
The macOS VNC client requires servers to configure a password
(although, it fails to make that obvious).