### PR TITLE
Pass the vm name to bhyveload guests as a variable.

### DIFF
--- a/lib/vm-guest
+++ b/lib/vm-guest
@@ -67,7 +67,7 @@ guest::load(){
     case "${_loader}" in
         bhyveload)
             _command="bhyveload"
-            _args="${_args}${_args:+ }-m ${_memory} -e smbios.system.uuid=${_uuid} -e autoboot_delay=${_timeout}"
+            _args="${_args}${_args:+ }-m ${_memory} -e smbios.system.uuid=${_uuid} -e autoboot_delay=${_timeout} -e bhyve_vm_name=${_name}"
 
             # look for custom bhyveload arguments
             config::get "_custom_args" "bhyveload_args"


### PR DESCRIPTION
Hi,

I'm using vm-bhyve with a NAT configuration, and using dnsmasq to perform DHCP. I also allowed it to serve names for the virtual machines and query it using a separate subdomain, forcing local_unbound to query the internal dnsmasq for that special domain.

This is very useful, allows me to ssh to freebsd hosts by name, simplifying key management for example.

As you may know, dnsmasq assigns dynamically the IP to the hostname submitted by the host. It works fine, but when I clone a machine multiple time the names clash.

With this patch the name of the machine is passed to the guest via loader env, then I can set it in the guest with this line in rc.conf:

```
hostname="$(/bin/kenv bhyve_vm_name).internal.vm"
```

and every clone automatically sets the correct hostname.

I'm using this with FreeBSD only, since I need this only there.

Not sure if anything like this can be done with windows guests, but I guess linux guests could get some similar functionality via grub.

Hope this is deemed useful!