### PR TITLE
Sound recording

### DIFF
--- a/lib/vm-run
+++ b/lib/vm-run
@@ -682,7 +682,7 @@ vm::bhyve_device_sound(){
     if config::yesno "sound"; then
         _devices="${_devices} -s ${_slot}:0,hda,play=${_play}"
 
-        if [ -n ${_rec} ]; then
+        if [ -n "${_rec}" ]; then
             _devices="${_devices},rec=${_rec}"
         fi
 

--- a/lib/vm-run
+++ b/lib/vm-run
@@ -675,11 +675,17 @@ vm::bhyve_device_mouse(){
 }
 
 vm::bhyve_device_sound(){
-    local _play
+    local _play _rec
     config::get "_play" "sound_play" "/dev/dsp0"
+    config::get "_rec" "sound_rec"
 
     if config::yesno "sound"; then
         _devices="${_devices} -s ${_slot}:0,hda,play=${_play}"
+
+        if [ -n ${_rec} ]; then
+            _devices="${_devices},rec=${_rec}"
+        fi
+
         _slot=$((_slot + 1))
     fi
 }

--- a/vm.8
+++ b/vm.8
@@ -1492,6 +1492,10 @@ for details.
 .It sound_play
 Set this to the desired audio output device of the host to the guest. Defaults to
 .Sy '/dev/dsp0'
+.It sound_play
+Set this to the desired audio input device of the host to the guest. If empty
+no audio input device is configured. Defaults to
+.Sy '' (empty)
 .It virt_consoleX
 Allows the creation of up to 16 virtio-console devices in the guest. The value
 to this option can be

--- a/vm.8
+++ b/vm.8
@@ -1492,7 +1492,7 @@ for details.
 .It sound_play
 Set this to the desired audio output device of the host to the guest. Defaults to
 .Sy '/dev/dsp0'
-.It sound_play
+.It sound_rec
 Set this to the desired audio input device of the host to the guest. If empty
 no audio input device is configured. Defaults to
 .Sy '' (empty)


### PR DESCRIPTION
Hi,

Since I also sometimes need audio input to machines, I thought I could add an option to allow that.

I added an option `sound_rec` that can be filled with a devince name and will be passed to bhyve. If empty no recording device will be created.

Not sure if this is the best interface, it provides no default value for the device.

If required I could add a further yes|no variable with some reasonable name (can't come up with any meaningful ones)