### PR TITLE
Syntax error in vm-migration

### DIFF
--- a/lib/vm-migration
+++ b/lib/vm-migration
@@ -142,7 +142,7 @@ migration::run(){
 
         while [ ${_count} -lt 60 ]; do
             sleep 2
-            kill ${_pid} >/dev/null 2>&1 || break
+            kill -0 ${_pid} >/dev/null 2>&1 || break
             echo -n "."
             _count=$((_count + 1))
         done
@@ -151,7 +151,7 @@ migration::run(){
     fi
 
     # has it stopped?
-    kill ${_pid} >/dev/null 2>&1 && util::err_inline "failed to stop guest"
+    kill -0 ${_pid} >/dev/null 2>&1 && util::err_inline "failed to stop guest"
     echo "  * stage 2: guest powered off"
 
     # only needed if running or specifically doing a stage 2

--- a/lib/vm-migration
+++ b/lib/vm-migration
@@ -142,7 +142,7 @@ migration::run(){
 
         while [ ${_count} -lt 60 ]; do
             sleep 2
-            kill -0 ${_pid} >/dev/null 2>&1 || break
+            kill ${_pid} >/dev/null 2>&1 || break
             echo -n "."
             _count=$((_count + 1))
         done
@@ -151,7 +151,7 @@ migration::run(){
     fi
 
     # has it stopped?
-    kill -0 ${_pid} >/dev/null 2>&1 && util:err_inline "failed to stop guest"
+    kill ${_pid} >/dev/null 2>&1 && util::err_inline "failed to stop guest"
     echo "  * stage 2: guest powered off"
 
     # only needed if running or specifically doing a stage 2


### PR DESCRIPTION
Wrong kill type and typo on util::err_inline function name