### PR TITLE
fix bad "_netgraph," variable

### DIFF
--- a/lib/vm-info
+++ b/lib/vm-info
@@ -96,7 +96,7 @@ info::switch(){
 #
 info::switch_show(){
     local _switch="$1"
-    local _type _bridge _vale _netgraph, _id
+    local _type _bridge _vale _netgraph _id
     local _INDENT="  "
 
     [ -z "${_switch}" ] && return 1


### PR DESCRIPTION
Fix "local: _netgraph,: bad variable name" warning when running `vm switch info`