### PR TITLE
Handle config lines that use single quotes instead of double quotes

### DIFF
--- a/lib/vm-config
+++ b/lib/vm-config
@@ -59,7 +59,10 @@ config::get(){
 
     for _c_line in ${VM_CONFIG}; do
         if [ "${_c_key}" = "${_c_line%%=*}" ]; then
-            setvar "${_c_var}" "${_c_line#*=}"
+            _c_line="${_c_line#*=}"
+            _c_line="${_c_line#\'}"
+            _c_line="${_c_line%\'}"
+            setvar "${_c_var}" "${_c_line}"
             return 0
         fi
     done


### PR DESCRIPTION
For example:
`network1_switch='int1'`

Would return `'int1'` instead of `int1` causing the md5 to not match.