### PR TITLE
fix: s/qemu-utils/qemu-tools/g

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,9 +254,9 @@ See the man page for a full description of all available commands.
 
 You can use cloud images to create virtual machines. The `vm img` command will download the image to datastore and 
 uncompress it if needed (.xz, .tar.gz, and .gz files are supported). The image should be in RAW or QCOW2 format.
-To use this feature you'll need install qemu-utils package:
+To use this feature you'll need install qemu-tools package:
 
-    # pkg install qemu-utils
+    # pkg install qemu-tools
 
 To launch FreeBSD using official cloud image:
 

--- a/lib/vm-core
+++ b/lib/vm-core
@@ -984,7 +984,7 @@ core::decompress(){
 core::img(){
     local _url _ds="default" _filename
     if ! which qemu-img > /dev/null; then
-        util::err "Error: qemu-img is required to work with cloud images! Run 'pkg install qemu-utils'."
+        util::err "Error: qemu-img is required to work with cloud images! Run 'pkg install qemu-tools'."
     fi
 
     while getopts d:u _opt ; do


### PR DESCRIPTION
There's no `qemu-utils` package anymore, `qemu-img` is now part of the `qemu-tools` package.