### PR TITLE
Make 'vm install' fetch from URIs for one-off installs

### DIFF
--- a/lib/vm-core
+++ b/lib/vm-core
@@ -476,7 +476,7 @@ core::add_network(){
 # @param string _iso the iso file in $vm_dir/.iso to use
 #
 core::install(){
-    local _name _iso _fulliso
+    local _name _iso _fulliso _fetched
 
     cmd::parse_args "$@"
     shift $?
@@ -486,8 +486,21 @@ core::install(){
     [ -z "${_name}" -o -z "${_iso}" ] && util::usage
 
     # just run start with an iso
-    datastore::iso_find "_fulliso" "${_iso}" || util::err "unable to locate iso file - '${_iso}'"
+    if ! datastore::iso_find "_fulliso" "${_iso}"; then
+	    util::warn "unable to locate iso file - '${_iso}', attempting fetch from URL"
+	    if ! datastore::get_iso default || ! fetch -o "${VM_DS_PATH}" "${_iso}"; then
+		    util::err "unable to fetch iso - '${_iso}'"
+	    fi
+	    _iso=$(basename "${_iso}")
+	    if ! datastore::iso_find "_fulliso" "${_iso}"; then
+		    util::err "unable to find fetched iso - '${_iso}'"
+	    fi
+	    _fetched=${_fulliso}
+    fi
     core::__start "${_name}" "${_fulliso}"
+    if [ -n "${_fetched}" ]; then
+	    rm -f "${_fetched}"
+    fi
 }
 
 # 'vm startall'

--- a/vm.8
+++ b/vm.8
@@ -77,7 +77,6 @@
 .Op Fl s Ar size
 .Ar name
 .Nm
-.Cm
 .Cm destroy
 .Op Fl f
 .Ar name
@@ -667,15 +666,24 @@ for each virtual interface.
 .Xc
 Start a guest installation for the named virtual machine, using the specified
 ISO file or install disk image.
+.Pp
 The
 .Ar iso
-argument should be the filename of an ISO or image file already downloaded into the
+argument can be the filename of an ISO or image file already downloaded into the
 .Pa $vm_dir/.iso
 directory (or any media datastore), a full path, or a file in the current
 directory.
-ISO files in the default .iso store can be downloaded using the
+ISO files can be downloaded to the default .iso store using the
 .Ar iso
 subcommand described below.
+.Pp
+Alternately, the
+.Ar iso
+argument can be a URL specifying the location of an ISO file.
+In that case, the file will be fetched to the default media datastore,
+the install will be started, and the file will be deleted when the
+command completes.
+This is useful when you do not expect to install from the same file again.
 .Pp
 By default the installation is started in the background.
 Use the


### PR DESCRIPTION
As a developer, I often have to do an install once from an ISO build fetched from somewhere.

This extends `vm install` to try fetching the ISO named passed as a URL if it isn't found locally, and to delete it after the command exit.  It's a little simple-minded but it helps me, maybe it'll help someone else.
