### PR TITLE
support ipv6 gateway on cloud init VMs

### DIFF
--- a/lib/vm-core
+++ b/lib/vm-core
@@ -265,7 +265,10 @@ core::create_cloud_init(){
         _network_config_gateway="$(echo "${_network_config}" | pcregrep -o "gateway=\K[^;]*")"
         _network_config_nameservers="$(echo "${_network_config}" | pcregrep -o "nameservers=\K[^;]*")"
         _network_config_hostname="$(echo "${_network_config}" | pcregrep -o "hostname=\K[^;]*")"
-
+        _network_ip_version="4"
+        if [[ $_network_config_ipaddress = *:* ]]; then
+            _network_ip_version="6"
+        fi
         # Override default hostname when network config is passed to cloud-init
         if [ ! -z "${_network_config_hostname}" ]; then
                 _hostname="${_network_config_hostname}"
@@ -280,7 +283,7 @@ ethernets:
       macaddress: "${_mac}"
     addresses:
       - ${_network_config_ipaddress}
-    gateway4: ${_network_config_gateway}
+    gateway${_network_ip_version}: ${_network_config_gateway}
     nameservers:
       search: []
       addresses: [${_network_config_nameservers}]


### PR DESCRIPTION
currently the network-config written for cloud init VMs is assuming that the gateway IP will be ipv4.

This commit simply checks if the IP contains a `:` and changes to using gateway6 key in the network-config in this case

I am not certain if there are other places that might break IPv6 usage, but this was one place that seemed like an easy fix.