### PR TITLE
vm-zfs: updated regex for specify options

### DIFF
--- a/lib/vm-zfs
+++ b/lib/vm-zfs
@@ -140,7 +140,7 @@ zfs::__format_options(){
     local _c_opts="$2"
 
     if [ -n "${_c_opts}" ]; then
-        _c_opts=$(echo "${_c_opts}" |sed -e 's/\ / -o /')
+        _c_opts=$(echo "${_c_opts}" |sed -E -e 's/[ \t]+/ -o /g')
         _c_opts="-o ${_c_opts}"
         setvar "${_val}" "${_c_opts}"
         return 0


### PR DESCRIPTION
There's a replace regex in `zfs::__format_options()` supported one option only.

The proposal patch added `global` flag for supporting several options.