### PR TITLE
Fix UEFI VM options

### DIFF
--- a/lib/vm-run
+++ b/lib/vm-run
@@ -109,7 +109,7 @@ vm::run(){
     fi
 
     # default bhyve options
-    _opts="-AHP"
+    _opts="-AHPw"
 
     # ignore access to unimplemented Model Specific Registers?
     config::yesno "ignore_msr" && _opts="${_opts}w"
@@ -319,7 +319,7 @@ vm::uefi(){
         _bootrom="${_bootrom},${VM_DS_PATH}/${_name}/uefi-vars.fd"
     fi
 
-    _opts="-Hwl bootrom,${_bootrom}"
+    _opts="${_opts} -l bootrom,${_bootrom}"
     _uefi="yes"
 }
 


### PR DESCRIPTION
Currently, `vm::run` initializes `_opts` to `-AHP`, then, in the UEFI case calls `vm::uefi` which, instead of _appending_ to `_opts`, _sets_ it to `-Hwl bootrom,...`. This means UEFI VMs are started without `-A`, which was never a good idea but which causes them to fail to boot with recent versions of `edk2-bhyve` (see https://bugs.freebsd.org/273560).

The main purpose of this PR is to change `vm::uefi` to _append_ to `_opts` so `-A` is not lost and UEFI VMs boot correctly.

In addition, it moves the `-w` option from UEFI-only to default, and deduplicates the `-H` option.