### PR TITLE
Support for additional priority types.

### DIFF
--- a/lib/vm-rctl
+++ b/lib/vm-rctl
@@ -46,7 +46,15 @@ rctl::set(){
     [ -z "${_pid}" ] && return 1
 
     # check for a priority
-    [ -n "${_pri}" ] && renice ${_pri} ${_pid} >/dev/null 2>&1
+    if [ -n "${_pri}" ]; then
+        if [ "${_pri%%[0-9]*}" = "i" ]; then
+    	    idprio ${_pri#i} -${_pid} >/dev/null 2>&1
+    	elif [ "${_pri%%[0-9]*}" = "r" ]; then
+    	    rtprio ${_pri#r} -${_pid} >/dev/null 2>&1
+    	else
+    	    renice ${_pri} ${_pid} >/dev/null 2>&1
+    	fi
+    fi
 
     # return if there are no limits
     [ -z "${_pcpu}${_rbps}${_wbps}${_riops}${_wiops}" ] && return 1

--- a/vm.8
+++ b/vm.8
@@ -1546,10 +1546,13 @@ Note that although the guest is technically stopped when this process runs, call
 will still consider the guest locked.
 .It priority
 Allows a priority to be set for a guest by using the
-.Xr nice 8
-facility. The default value is 0, and has a range from -20, which is the highest
+.Xr nice 1
+or
+.Xr rtprio 1
+facilities. The default value is 0, and has a range from -20, which is the highest
 priority, to 20. A priority of 20 will cause the guest to only run when the host
-system is idle.
+system is idle. Priority values prefixed with "r" or "i" will set realtime or idletime 
+priorities, respectively.
 .It limit_pcpu
 Limit the bhyve process to the specified cpu percentage.
 .Pp


### PR DESCRIPTION
This minor change adds support for specifying realtime or idletime priorities by specifying the priority as "rNN" for realtime or "iNN" for idletime priorities.
