### PR TITLE
Fix and update OpenBSD template

### DIFF
--- a/sample-templates/openbsd.conf
+++ b/sample-templates/openbsd.conf
@@ -1,10 +1,17 @@
-loader="grub"
+loader="uefi"
 cpu=1
-memory=256M
+memory=512M
 network0_type="virtio-net"
 network0_switch="public"
 disk0_type="virtio-blk"
 disk0_name="disk0.img"
-grub_install0="kopenbsd -h com0 /6.2/amd64/bsd.rd"
-grub_run0="kopenbsd -h com0 -r sd0a /bsd"
 bhyve_options="-w"
+graphics="yes"
+xhci_mouse="yes"
+graphics_res="1600x900"
+graphics_wait="no"
+# Uncomment two lines below and download installXX.img, place in vm folder.
+# Replace XX with OpenBSD version.
+# You can delete the two lines below when installation is done
+#disk1_type="virtio-blk"
+#disk1_name="installXX.img"


### PR DESCRIPTION
OpenBSD does not support kopenbsd from grub anymore: using uefi. Increaced minimum ram requirement. Added graphics: com0/1, stdio are currently not working.