### PR TITLE
RC order fix

### DIFF
--- a/rc.d/vm
+++ b/rc.d/vm
@@ -3,8 +3,7 @@
 # $FreeBSD$
 
 # PROVIDE: vm
-# REQUIRE: NETWORKING SERVERS dmesg
-# BEFORE: dnsmasq ipfw pf
+# REQUIRE: DAEMON vm_net
 # KEYWORD: shutdown nojail
 
 . /etc/rc.subr
@@ -23,7 +22,6 @@ stop_cmd="${command} stopall -f"
 
 vm_start()
 {
-    env rc_force="$rc_force" ${command} init
     env rc_force="$rc_force" ${command} startall >/dev/null &
 }
 

--- a/rc.d/vm_net
+++ b/rc.d/vm_net
@@ -1,0 +1,27 @@
+#!/bin/sh
+#
+# $FreeBSD$
+
+# PROVIDE: vm_net
+# REQUIRE: bridge
+# BEFORE: dnsmasq ipfw pf
+# KEYWORD: nojail
+
+. /etc/rc.subr
+
+: ${vm_enable="NO"}
+
+name=vm
+desc="Start networking (bridges) for vm-bhyve guests on boot"
+rcvar=vm_enable
+
+load_rc_config $name
+
+start_cmd="${name}_start"
+
+vm_start()
+{
+    env rc_force="$rc_force" ${command} init
+}
+
+run_rc_command "$1"

--- a/rc.d/vm_net
+++ b/rc.d/vm_net
@@ -17,6 +17,7 @@ rcvar=vm_enable
 
 load_rc_config $name
 
+command="/usr/local/sbin/${name}"
 start_cmd="${name}_start"
 
 vm_start()

--- a/vm.8
+++ b/vm.8
@@ -1304,6 +1304,15 @@ detected and used by setting this option to
 and
 .Pa diskX_name
 as described above.
+.Pp
+When
+.Sy iscsi
+disks are used with auto-start, set the following in
+.Pa /etc/rc.conf
+to prevent launching vms before iscsi connections are completed:
+.Bd -literal -offset indent
+iscsictl_flags="-Aa -w 60"
+.Ed
 .It disk0_opts
 Any additional options to use for this disk device.
 Multiple options can be specified, separated by a comma.


### PR DESCRIPTION
Split startup into two phases (bridges/vms)

The current rc.d/vm REQUIREs 'NETWORKING' but is also BEFORE pf/ipfw. This is not well formed (as NETWORKING relies on pf/ipfw), but is desired to generate bridges before pf/ipfw are generated. Likewise for iscsi attachments to work, vm auto-booting should be after NETWORKING.

Split into vm_net (early / bridge generation) and vm (late / vm start as well as shutdown) phases/rc.d files. This allows non-circular ordering of dependencies.

We don't currently have a clean way to stop and restart the 'init' phase, especially in light of potentially needing to reload firewalls rules.

This still uses the same vm_enable rcvar, so there is no change in "user interface"