### PR TITLE
Make ubuntu cloud images work with zvols

### DIFF
--- a/lib/vm-core
+++ b/lib/vm-core
@@ -223,11 +223,11 @@ core::create(){
 
     # create each disk
     while [ -n "${_disk}" ]; do
-        case "${_disk_dev}" in 
+        case "${_disk_dev}" in
             zvol)
                 zfs::make_zvol "${VM_DS_ZFS_DATASET}/${_name}/${_disk}" "${_disk_size}" "0" "${_zfs_opts}"
                 [ $_num -eq 0 ] && [ ! -z "$_img" ] && core::write_img "/dev/zvol/${VM_DS_ZFS_DATASET}/${_name}/${_disk}" "${_img}"
-                ;;			
+                ;;
             sparse-zvol)
                 zfs::make_zvol "${VM_DS_ZFS_DATASET}/${_name}/${_disk}" "${_disk_size}" "1" "${_zfs_opts}"
                 [ $_num -eq 0 ] && [ ! -z "$_img" ] && core::write_img "/dev/zvol/${VM_DS_ZFS_DATASET}/${_name}/${_disk}" "${_img}"
@@ -318,7 +318,7 @@ EOF
     fi
 
     genisoimage -output "${VM_DS_PATH}/${_name}/seed.iso" -volid cidata -joliet -rock ${_cloud_init_dir}/* > /dev/null 2>&1 || util::err "Can't write seed.iso for cloud-init"
-    config::set "${_name}" "disk${_num}_type" "ahci-cd"
+    config::set "${_name}" "disk${_num}_type" "virtio-blk"
     config::set "${_name}" "disk${_num}_name" "seed.iso"
     config::set "${_name}" "disk${_num}_dev" "file"
 }
@@ -330,7 +330,7 @@ EOF
 # @param string _img the img file in $vm_dir/.img to use
 #
 core::write_img(){
-    local _disk_dev _img _imgpath
+    local _disk_dev _img _imgpath dd_status
 
     cmd::parse_args "$@"
     shift $?
@@ -339,22 +339,18 @@ core::write_img(){
     timeout=30
     i=0
 
-    # wait a few seconds for newly created zvol device to appear
-    while [ $i -lt $timeout ]; do
-        if [ ! -r "${_disk_dev}" ]; then
-            sleep 1
-            i=$(($i+1))
-	else
-            break
-        fi
-    done
-
     # just run start with an iso
     datastore::img_find "_imgpath" "${_img}" || util::err "unable to locate img file - '${_img}'"
-    qemu-img dd -O raw if="${_imgpath}" of="${_disk_dev}" bs=1M
-    if [ $? -ne 0 ]; then
-        util::err "failed to write img file with qemu-img"
-    fi
+
+    # even if the zvol is present, it might not be ready just yet (Device busy).
+    while [ $i -lt $timeout ] ; do
+        qemu-img dd -O raw if="${_imgpath}" of="${_disk_dev}" bs=1M > /dev/null 2>&1
+        dd_status=$?
+        [ $dd_status -eq 0 ] && break
+        sleep 1
+        i=$(($i+1))
+    done
+    [ $dd_status -ne 0 ] && util::err "failed to write img file with qemu-img"
 }
 
 # 'vm add'


### PR DESCRIPTION
Version 1.5 as in the FreeBSD packages fails to import a Ubuntu 22.04 Cloud image - and most likely others.
```
sudo vm img
DATASTORE           FILENAME
default             jammy-server-cloudimg-amd64-disk-kvm.img

cat /bhyve/vm/.templates/cloud-zvol-ubuntu.conf 
loader="uefi"
cpu=1
memory=1G
network0_type="virtio-net"
network0_switch="public"
disk0_name="disk0"
disk0_dev="sparse-zvol"
disk0_type="virtio-blk"
```
The following command lead to an error by qemu-img dd -> device busy.
```
sudo vm create -t cloud-zvol-ubuntu -s 6G -i jammy-server-cloudimg-amd64-disk-kvm.img -C -n "ip=192.168.xxx.yyy/24;gateway=192.168.xxx.yyy;nameservers=192.168.xxx.yyy" -k ~/falpi_df_id_rsa.pub showcase1
```

The changes I made repeat the qemu-img command for up to 30 times with a 1 second sleep to allow the zvol to come up and be actually ready to be written on.
Additionally the hard coded disk type in core::create_cloud_init has been changed to virtio-blk, since at least the Ubuntu cloud images require this to have cloud init working.

This is my first ever pull request - so in case there is something wrong, just let me know ;)

Greetings,
Dirk
