### PR TITLE
Increase memory in Ubuntu template

### DIFF
--- a/sample-templates/ubuntu.conf
+++ b/sample-templates/ubuntu.conf
@@ -1,6 +1,6 @@
 loader="grub"
 cpu=1
-memory=512M
+memory=1024M
 network0_type="virtio-net"
 network0_switch="public"
 disk0_type="virtio-blk"


### PR DESCRIPTION
Recent versions of Ubuntu require more than 512M to even boot, since the initramfs is large.

When I was trying to boot Ubuntu 20 and Ubuntu 22 installer images, I was getting this error, followed by a kernel panic: `Initramfs unpacking failed: write error`