### PR TITLE
Ignore empty lockfiles

### DIFF
--- a/lib/vm-core
+++ b/lib/vm-core
@@ -80,7 +80,7 @@ core::list(){
 
                 # check if the guest is running
                 if vm::running_check "_run" "_pid" "${_name}" || \
-                    [ -e "${VM_DS_PATH}/${_name}/run.lock" -a "$(head -n1 ${VM_DS_PATH}/${_name}/run.lock 2>/dev/null)" = "${_our_host}" ]; then
+                    [ -s "${VM_DS_PATH}/${_name}/run.lock" -a "$(head -n1 ${VM_DS_PATH}/${_name}/run.lock 2>/dev/null)" = "${_our_host}" ]; then
 
                     # if running and graphics, try to get vnc port
                     if config::yesno "graphics"; then
@@ -112,7 +112,7 @@ core::list(){
                 done
 
                 # if stopped, see if it's locked by another host
-                if [ "${_run}" = "Stopped" -a -e "${VM_DS_PATH}/${_name}/run.lock" ]; then
+                if [ "${_run}" = "Stopped" -a -s "${VM_DS_PATH}/${_name}/run.lock" ]; then
                     _run=$(head -n1 "${VM_DS_PATH}/${_name}/run.lock")
                     _run="Locked (${_run})"
                 fi

--- a/lib/vm-run
+++ b/lib/vm-run
@@ -884,7 +884,7 @@ vm::confirm_stopped(){
 
     # check vm-bhyve lock
     # this will err even if guest is running on another node
-    if [ -e "${VM_DS_PATH}/${_name}/run.lock" ]; then
+    if [ -s "${VM_DS_PATH}/${_name}/run.lock" ]; then
         _host=$(head -n 1 "${VM_DS_PATH}/${_name}/run.lock")
 
         if [ "${_host}" != "${_our_host}" -o "${_skip_lock}" != "1" ]; then


### PR DESCRIPTION
Empty lockfile could appear in case of panic, unexpected reboot/power cycle shortly after VM start command.
In such cases, lockfile's metadata might have been already synced to disk, but the file contents itself is not.
After reboot, this results in an empty lock file, which prevents VM from start; as hostname stored in such lockfile (nothing/empty string) doesn't match to hostname.