### PR TITLE
Added support for interface name in cloud-init, implements #559

### DIFF
--- a/lib/vm-core
+++ b/lib/vm-core
@@ -266,7 +266,8 @@ core::create_cloud_init(){
     mkdir -p "${_cloud_init_dir}"
 
     if [ -n "${_network_config}" ]; then
-        # Example netconfig param: "ip=10.0.0.2/24;gateway=10.0.0.1;nameservers=1.1.1.1,8.8.8.8"
+        # Example netconfig param: "interface=vio0;ip=10.0.0.2/24;gateway=10.0.0.1;nameservers=1.1.1.1,8.8.8.8"
+        _network_config_interface="$(echo "${_network_config}" | pcregrep -o "interface=\K[^;]*" || true)"; _network_config_interface="${_network_config_interface:-eth0}"
         _network_config_ipaddress="$(echo "${_network_config}" | pcregrep -o "ip=\K[^;]*")"
         _network_config_gateway="$(echo "${_network_config}" | pcregrep -o "gateway=\K[^;]*")"
         _network_config_nameservers="$(echo "${_network_config}" | pcregrep -o "nameservers=\K[^;]*")"
@@ -281,7 +282,7 @@ core::create_cloud_init(){
 version: 2
 ethernets:
   id0:
-    set-name: eth0
+    set-name: ${_network_config_interface}
     match:
       macaddress: "${_mac}"
     addresses:


### PR DESCRIPTION
Implements interface name specification for `set-name` in cloud-init, this is required to set e.g. `vio0` on OpenBSD, the default value `eth0` will not work there. Example:
```
cat bhyve-openbsd-cloud.sh
sudo vm create \
-t openbsd \
-s 4G \
-c 2 \
-m 512M \
-i openbsd-min.qcow2 \
-C -n "interface=vio0;ip=192.168.1.12/24;gateway=192.168.1.1;nameservers=192.168.1.1" \
-k /home/user/.ssh/id_rsa.pub \
openbsd-test-cloud
```