### PR TITLE
Allow vnet-enabled jails

### DIFF
--- a/rc.d/vm
+++ b/rc.d/vm
@@ -5,7 +5,7 @@
 # PROVIDE: vm
 # REQUIRE: NETWORKING SERVERS dmesg
 # BEFORE: dnsmasq ipfw pf
-# KEYWORD: shutdown nojail
+# KEYWORD: shutdown nojailvnet
 
 . /etc/rc.subr
 


### PR DESCRIPTION
This PR adds support for vnet-enabled jails to `rc.d/vm`, which addresses FreeBSD [Bug 282651](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=282651). Thanks for an excellent project, I can't imagine managing bhyve any other way!