### PR TITLE
Feature to support mixed access and vlan interfaces in a switch

### DIFF
--- a/lib/vm-switch-standard
+++ b/lib/vm-switch-standard
@@ -281,6 +281,12 @@ switch::standard::__configure_port(){
     # try to set mtu of port?
     [ -n "${_mtu}" ] && ifconfig "${_port}" mtu ${_mtu} >/dev/null 2>&1
 
+    # no vlan, but this port?
+    if [ -z "${_vlan}" -a "${_port}" != "${_port#*.}" ]; then
+        _vlan="${_port#*.}"
+        _port="${_port%.*}"
+    fi
+
     # vlan enabled?
     if [ -n "${_vlan}" ]; then
 


### PR DESCRIPTION
Minimalist implementation of the possibility to add access interfaces and vlan tagged interfaces into the same switch.

Eg.:
```
pasztor@host:~ $ sudo vm switch list
NAME      TYPE      IFACE        ADDRESS        PRIVATE  MTU  VLAN  PORTS
test      standard  vm-test      -              no       -    -     vxlan42 epair0b.1042
```
vxlan42 is created using rc.conf's cloned interfaces and it doesn't need .1q tagging, but the other member port on epair0b it ineed needs it.

Thoroughly tested and proven to work.