### PR TITLE
Add support for Fwcfg type configuration of bootroom as now supported by bhyve.

### DIFF
--- a/lib/vm-run
+++ b/lib/vm-run
@@ -276,6 +276,7 @@ vm::run(){
 #
 vm::uefi(){
     local _bootrom
+    local _fwcfg_type
 
     if [ ${VERSION_BSD} -lt 1002509 ]; then
         util::log "guest" "${_name}" "fatal; uefi guests can only be run on FreeBSD 10.3 or newer"
@@ -317,6 +318,12 @@ vm::uefi(){
         fi
 
         _bootrom="${_bootrom},${VM_DS_PATH}/${_name}/uefi-vars.fd"
+    fi
+
+    # configure fwcfg type if specified in configuration
+    config::get "_fwcfg_type" "fwcfg_type" ""
+    if [ ! -z "_fwcfg_type" ]; then
+       _bootrom="${_bootrom},fwcfg=${_fwcfg_type}"
     fi
 
     _opts="-Hwl bootrom,${_bootrom}"

--- a/sample-templates/flatcar.conf
+++ b/sample-templates/flatcar.conf
@@ -1,0 +1,18 @@
+# Use GRUB when booting from an installation medium
+#loader="grub"
+
+# Use UEFI when booting from a disk image
+loader="uefi"
+
+# Use QEMU Firmware Configuration (fw_cfg) Device for passing ignition file on first startup
+# -A bhyve option to Generate ACPI tables
+# -f bhyve option reads the file and adds	the file content as fw_cfg data.	
+fwcfg_type="qemu"
+bhyve_options="-A -f name=opt/org.flatcar-linux/config,file=/zroot/vm/$vm/provision.ign"
+  
+cpu=1
+memory=1024M
+network0_type="virtio-net"
+network0_switch="public"
+disk0_type="virtio-blk"
+disk0_name="disk0.img"

--- a/vm.8
+++ b/vm.8
@@ -1117,6 +1117,13 @@ and rely on UEFI variables to locate it. The version of
 installed must provide the template data file, and support also needs to be present
 in
 .Sy bhyve
+.It fwcfg_type 
+Setting this option will set the Fwcfg type as supported by bhyve by adding ,fwcfg=type on the bootrom.
+Bhyve added support for QEMU Firmware Configuration Device fwcfg_type="qemu".
+This may be required for some guests that use the firmware device to pass arguments to the vm.
+uefi-firmware needs to be present in 
+.Sy bhyve
+.It 
 .It bhyveload_loader
 This option allows a custom path to be used for the loader inside the guest.
 Passed to


### PR DESCRIPTION
Bhyve added support for QEMU Firmware Configuration (fw_cfg) Device. 

These changes enable configuring the vm to use qemu firmware instead of default fwctl.

Added a template for flatcar linux that uses the new configuration to pass "ignition" file for vm configuration through the firmware.

Update man page.