### PR TITLE
fix: Restore verbose option to list command

### DIFF
--- a/lib/vm-core
+++ b/lib/vm-core
@@ -34,15 +34,13 @@ core::list(){
     local _state _pcpu _rss _uptime
     local _format="%s^%s^%s^%s^%s^%s^%s^%s\n"
 
-    while getopts r _opt ; do
-        case $_opt in
+    while getopts rv _opt ; do
+        case ${_opt} in
             r) _running_only='true' ;;
-
+            v) VM_OPT_VERBOSE="1" ;;
             *) util::usage ;;
         esac
     done
-
-    shift $?
 
     _our_host=$(hostname)
 

--- a/vm.8
+++ b/vm.8
@@ -83,7 +83,7 @@
 .Ar name
 .Nm
 .Cm list
-.Op Fl r
+.Op Fl rv
 .Nm
 .Cm info
 .Op Ar name
@@ -650,14 +650,16 @@ Removes the specified virtual machine from the system, deleting all associated
 disk images & configuration.
 .It Xo
 .Cm list
-.Op Fl r
+.Op Fl rv
 .Xc
 .br
 List all the virtual machines in the
 .Pa $vm_dir
 directory.
 This will show the basic configuration for each virtual machine, and whether
-they are currently running.
+they are currently running. Using the
+.Ar -v
+option displays additional information about each virtual machine.
 .Pp
 If the
 .Ar -r


### PR DESCRIPTION
Commit 378d95e ("Add option to only list running VMs") removed the call to cmd::parse_args which supported the -v ("verbose") option. Add back the ability to pass the -v option directly instead of using the utility function itself.

While here, also update the man page to document the verbose option.

Reported-by: drTr0jan