### PR TITLE
remove redundant w opt with ignore_msr

### DIFF
--- a/lib/vm-run
+++ b/lib/vm-run
@@ -111,9 +111,6 @@ vm::run(){
     # default bhyve options
     _opts="-AHPw"
 
-    # ignore access to unimplemented Model Specific Registers?
-    config::yesno "ignore_msr" && _opts="${_opts}w"
-
     # if uefi, make sure we have bootrom, then update options for uefi support
     if [ "${_loader%-*}" = "uefi" ]; then
         vm::uefi


### PR DESCRIPTION
With merged PR #525, we add `-w` to the default` _opts` on line 112 which makes checking `config::yesno "ignore_msr"` and conditionally adding `w` via `&& _opts="${_opts}w"` on line 115 redundant.

Does something else need to be done for Model Specific Registers?
With the addition of `w` as default, nothing is then changed for msr, but I don't know what would be.