### PR TITLE
Support multiple ZFS properties in zfs_zvol_opts

### DIFF
--- a/lib/vm-zfs
+++ b/lib/vm-zfs
@@ -140,7 +140,7 @@ zfs::__format_options(){
     local _c_opts="$2"
 
     if [ -n "${_c_opts}" ]; then
-        _c_opts=$(echo "${_c_opts}" |sed -e 's/\ / -o /')
+        _c_opts=$(echo "${_c_opts}" |sed -e 's/\ / -o /g')
         _c_opts="-o ${_c_opts}"
         setvar "${_val}" "${_c_opts}"
         return 0


### PR DESCRIPTION
This PR allows more than two properties to be specified in `zfs_vol_opts`. Prior to this change, if templates specified more than two properties, the `-o` flag would be skipped for subsequent properties, resulting in a failed call to `zfs create`. The fix is very simple; adding the `g` flag allows substitution for all non-overlapping matches in sed.

For example, a template with `zfs_zvol_opts="volblocksize=4k compression=off autobackup:local=false"` results in the following:
```
# sh -x /usr/local/sbin/vm create -t example -s 32G test
...
+ zfs create -sV 32G -o 'volmode=dev' -o 'volblocksize=4k' -o 'compression=off' 'autobackup:local=false' zroot/vm/test/disk0
too many arguments
usage:
        create [-Pnpuv] [-o property=value] ... <filesystem>
        create [-Pnpsv] [-b blocksize] [-o property=value] ... -V <size> <volume>

For the property list, run: zfs set|get

For the delegated permission list, run: zfs allow|unallow
```
With the patch applied, the zvol is created with the specified properties as expected.