### PR TITLE
Update vm-datastore: correct typo 'datstore' to 'datastore' in existing datastore error message

### DIFF
--- a/lib/vm-datastore
+++ b/lib/vm-datastore
@@ -96,7 +96,7 @@ datastore::add(){
 
     # check name not in use
     for _curr in ${VM_DATASTORE_LIST}; do
-        [ "${_curr}" = "${_name}" ] && util::err "datstore '${_name}' already exists!"
+        [ "${_curr}" = "${_name}" ] && util::err "datastore '${_name}' already exists!"
     done
 
     # look for zfs


### PR DESCRIPTION
fix: correct typo 'datstore' to 'datastore' in existing datastore error message

Updated the error string from "datstore '${_name}' already exists!" to "datastore '${_name}' already exists!" to fix a typo and improve clarity.